### PR TITLE
Convert underscores to dashes

### DIFF
--- a/lib/rubyoshka/renderer.rb
+++ b/lib/rubyoshka/renderer.rb
@@ -33,8 +33,8 @@ class Rubyoshka
 
     S_TAG_METHOD_LINE = __LINE__ + 1
     S_TAG_METHOD = <<~EOF
-      S_TAG_%<TAG>s_PRE = '<%<tag>s'
-      S_TAG_%<TAG>s_CLOSE = '</%<tag>s>'
+      S_TAG_%<TAG>s_PRE = '<%<tag>s'.tr("_", "-")
+      S_TAG_%<TAG>s_CLOSE = '</%<tag>s>'.tr("_", "-")
 
       def %<tag>s(text = nil, **props, &block)
         @buffer << S_TAG_%<TAG>s_PRE
@@ -88,7 +88,7 @@ class Rubyoshka
           raise e
         end
       else
-        tag = sym.to_s.tr("_", "-")
+        tag = sym.to_s
         code = S_TAG_METHOD % { tag: tag, TAG: tag.upcase }
         self.class.class_eval(code, __FILE__, S_TAG_METHOD_LINE)
         send(sym, *args, **opts, &block)

--- a/lib/rubyoshka/renderer.rb
+++ b/lib/rubyoshka/renderer.rb
@@ -88,7 +88,7 @@ class Rubyoshka
           raise e
         end
       else
-        tag = sym.to_s
+        tag = sym.to_s.tr("_", "-")
         code = S_TAG_METHOD % { tag: tag, TAG: tag.upcase }
         self.class.class_eval(code, __FILE__, S_TAG_METHOD_LINE)
         send(sym, *args, **opts, &block)
@@ -142,11 +142,11 @@ class Rubyoshka
         else
           case v
           when true
-            @buffer << S_SPACE << k.to_s
+            @buffer << S_SPACE << k.to_s.tr("_", "-")
           when false, nil
             # emit nothing
           else
-            @buffer << S_SPACE << k.to_s << S_EQUAL_QUOTE << v << S_QUOTE
+            @buffer << S_SPACE << k.to_s.tr("_", "-") << S_EQUAL_QUOTE << v << S_QUOTE
           end
         end
       }

--- a/lib/rubyoshka/renderer.rb
+++ b/lib/rubyoshka/renderer.rb
@@ -33,8 +33,8 @@ class Rubyoshka
 
     S_TAG_METHOD_LINE = __LINE__ + 1
     S_TAG_METHOD = <<~EOF
-      S_TAG_%<TAG>s_PRE = '<%<tag>s'.tr("_", "-")
-      S_TAG_%<TAG>s_CLOSE = '</%<tag>s>'.tr("_", "-")
+      S_TAG_%<TAG>s_PRE = '<%<tag>s'.tr('_', '-')
+      S_TAG_%<TAG>s_CLOSE = '</%<tag>s>'.tr('_', '-')
 
       def %<tag>s(text = nil, **props, &block)
         @buffer << S_TAG_%<TAG>s_PRE
@@ -142,11 +142,12 @@ class Rubyoshka
         else
           case v
           when true
-            @buffer << S_SPACE << k.to_s.tr("_", "-")
+            @buffer << S_SPACE << k.to_s.tr('_', '-')
           when false, nil
             # emit nothing
           else
-            @buffer << S_SPACE << k.to_s.tr("_", "-") << S_EQUAL_QUOTE << v << S_QUOTE
+            @buffer << S_SPACE << k.to_s.tr('_', '-') <<
+              S_EQUAL_QUOTE << v << S_QUOTE
           end
         end
       }

--- a/test/test_template.rb
+++ b/test/test_template.rb
@@ -82,10 +82,29 @@ class TagsTest < MiniTest::Test
     )
   end
 
+  def test_tag_underscore_to_hyphen_conversion
+    assert_equal(
+      '<my-nifty-tag>foo</my-nifty-tag>',
+      H { my_nifty_tag 'foo' }.render
+    )
+
+    assert_equal(
+      '<my-nifty-tag/>',
+      H { my_nifty_tag }.render
+    )
+  end
+
   def test_that_tag_method_accepts_text_and_attributes
     assert_equal(
       '<p class="hi">lorem ipsum</p>',
       H { p "lorem ipsum", class: 'hi' }.render
+    )
+  end
+
+  def test_attribute_underscore_to_hyphen_conversion
+    assert_equal(
+      '<p data-foo="bar">hello</p>',
+      H { p 'hello', data_foo: 'bar' }.render
     )
   end
 


### PR DESCRIPTION
This is a cool project! Just starting to play around with it in the context of Bridgetown templates.

One thing I noticed: I work a lot with custom elements, which per spec require dashes (aka `my-nify-tag`). Rubyoshka simply outputs such a tag with underscores intact, which I'm not sure makes sense in HTML anyway. Attribute names similarly output with underscores.

This PR adds a simple `tr` call in a couple of places so it can output the dashes.

So:

```ruby
H do
  custom_element_here "Hello", data_something: "value"
end
```

would become:

```html
<custom-element-here data-something="value">Hello</custom-element-here>
```