### PR TITLE
Quote 3.0 in CI matrix to avoid truncation.  Also eliminate duplicated bundle install step.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        ruby: [2.7, 3.0, 3.1, 3.2]
+        ruby: [2.7, "3.0", 3.1, 3.2]
 
     name: >-
       ${{matrix.os}}, ${{matrix.ruby}}
@@ -20,9 +20,5 @@ jobs:
       with:
         ruby-version: ${{matrix.ruby}}
         bundler-cache: true
-    - name: Install dependencies
-      run: |
-        gem install bundler
-        bundle install
     - name: Run tests
       run:  bundle exec ruby test/run.rb


### PR DESCRIPTION
You can see the impact of leaving out quotes in an earlier run here, where Ruby 3.2 is loaded for the entry where Ruby 3.0 is intended:

<img width="1092" alt="Screenshot 2023-02-16 at 8 39 29 AM" src="https://user-images.githubusercontent.com/421488/219382105-4a2a7656-d326-4a30-bc63-d5e3d4858852.png">
