### PR TITLE
Refactor Papercraft API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 3.0.0 2025-10-19
+
+- Improve implementation of `Papercraft.apply`
+- Add support for rendering self-closing XML tags
+- Streamline Papercraft API
+- Add support for `Papercraft.render { ... }`
+- Prefix internal Proc extensions with `__papercraft_`
+- Change API to use `Papercraft.html` instead of `Proc#render`. Same for
+  `apple`, `render_xml` etc.
+
 # 2.24 2025-10-14
 
 - Update gem links

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 ```ruby
 require 'papercraft'
 
-Papercraft.render {
+Papercraft.html {
   div {
     h1 "Hello from Papercraft!"
   }

--- a/README.md
+++ b/README.md
@@ -21,10 +21,12 @@
 ```ruby
 require 'papercraft'
 
--> {
-  h1 "Hello from Papercraft!"
-}.render
-#=> "<h1>Hello from Papercraft</h1>"
+Papercraft.render {
+  div {
+    h1 "Hello from Papercraft!"
+  }
+}
+#=> "<div><h1>Hello from Papercraft</h1></div>"
 ```
 
 Papercraft is a templating engine for dynamically producing HTML in Ruby apps.

--- a/TODO.md
+++ b/TODO.md
@@ -1,68 +1,184 @@
-## Existing
+## Support for inlining
+
+### Uses
+
+- components: `render Table, ...`
+- extensions: `foo_thing ...`
+- applied blocks: `render_yield ...`
+
+### Challenges
+
+- Whitespace: should be able to preserve whitespace, but the inlined code
+  should be kept on separate lines, i.e. leading and trailing `\n`.
+- Sourcemaps: generate sourcemap entries pointing to original code of
+  inlined proc.
+- Recursive inlining: Inlining should be recursive, such that inlined procs
+  should themselves go through the process of inlining. This also means that
+  the property of whether a proc can be inlined is also recursive. It can
+  only be inlined if its consitutent sub-templates are also inlineable.
+
+- Detect procs that can be inlined by interrogating the original proc's binding:
 
 ```ruby
-layout = ->(**) {
+# for local variable:
+o.binding.local_variable_defined?(:foo)
+o.binding.local_variable_get(:foo)
+
+# for const
+o.binding.eval('Foo')
+```
+
+- Detect whether proc can be inlined:
+
+  - No local var assignments (LocalVariableWriteNode)
+  - No return/break statements (BreakNode, ReturnNode)
+  - No rescue statements (RescueNode)
+
+```ruby
+Card = ->(title, text) {
+  card {
+    h1 title
+    p text
+  }
+}
+
+Content = -> {
+  Card(
+    "Foobar",
+    "Lorem ipsum"
+  )
+  Card(
+    "Barbaz",
+    "Schlorem ipsum"
+  )
+}
+
+#=>:
+->(__buffer__) {
+  card {
+    h1 "Foobar"
+    p "Lorem ipsum"
+  }
+  card {
+    h1 "Barbaz"
+    p "Schlorem ipsum"
+  }
+}
+```
+
+Actually, the entire thing could be done at the translation phase! When mutating
+the tree, we can just take the inlined proc, find its AST, make sure its
+inlineable, replace all parameter refs (LocalVariableReadNode) with the applied
+parameters, and replace the `render`, `render_yield`, or component method call
+with the inlined AST.
+
+### Keeping track of component and block references
+
+Consider the following:
+
+```ruby
+HeadLinks = ->(**props) {
+  props[:links].each {
+    link ...
+  }
+}
+
+DefaultLayout = ->(**props) {
   html {
+    head {
+      HeadLinks(**props)
+    }
     body {
-      render_children(**)
+      render_yield(**props)
     }
   }
 }
 
-page = layout.apply { |title:, **|
-  h1 title
+FancyLayout = Papercraft.apply(DefaultLayout) { |**props|
+  article {
+    render_yield(**props)
+  }
 }
 
-page.render(title: 'foo')
+SuperFancyLayout = Papercraft.apply(FancyLayout) { |**props|
+  h1 'foo'
+}
 ```
 
-## Alternative
+In order to apply it into a single compiled lambda, we need to somehow track the
+original procs and asts. For each proc, we can track its "dependencies" so to
+speak:
+
+- `HeadLinks`: no deps
+- `DefaultLayout`: deps: HeadLinks
+- `FancyLayout`: deps: FancyLayout
+- `SuperFancyLayout`: deps: SuperFancyLayout
+
+### Apply is more difficult for inlining
 
 ```ruby
-layout = ->(**) {
+InlinedDefaultLayout = ->(**props) {
   html {
+    head {
+      # inlined HeadLinks
+      props[:links].each {
+        link ...
+      }
+    }
     body {
-      render_children(**)
+      render_yield(**props)
     }
   }
 }
 
-page = Papercraft.apply(layout) { |title:, **|
-  h1 title
+InlinedFancyLayout = ->(**props) {
+  html {
+    head {
+      # HeadLinks(**props)
+      # inlined HeadLinks
+      props[:links].each {
+        link ...
+      }
+    }
+    body {
+      # render_yield(**props)
+      # inlined render_yield
+      article {
+        render_yield(**props)
+      }
+    }
+  }
 }
 
-Papercraft.render(page, title: 'foo')
+SuperFancyLayout = ->(**props) {
+  html {
+    head {
+      # HeadLinks(**props)
+      # inlined HeadLinks
+      props[:links].each {
+        link ...
+      }
+    }
+    body {
+      # render_yield(**props)
+      # inlined render_yield
+      article {
+        h1 'foo'
+      }
+    }
+  }
+}
+
 ```
 
-## Papercraft landing page example
+So each time we call apply, we need to take the previous step's AST and perform
+the inlining. So, that means we need to store the inlined AST in the original
+proc, so:
 
 ```ruby
-Papercraft.render(
-  -> {
-    h1 "Hello from Papercraft!"
-  }
-)
-#=> "<h1>Hello from Papercraft!</h1>"
+# The apply op first compiles DefaultLayout, which generates an inlined AST
+# which is then stored in the DefaultLayout object, and then this AST is mutated
+# to generate the applied AST - which injects the given block and / or arguments
+# into the mutated AST, which is then stored in FancyLayout, and so forth...
+FancyLayout = Papercraft.apply(DefaultLayout) { ... } 
 ```
-
-## API
-
-- [ ] Support for inlining (needed for doing extension procs - see below)
-
-  - [ ] Detect procs that can be inlined by interrogating the original
-        proc's binding:
-
-        ```ruby
-        # for local variable:
-        o.binding.local_variable_defined?(:foo)
-        o.binding.local_variable_get(:foo)
-
-        # for const
-        o.binding.eval('Foo')
-        ```
-
-  - [ ] Detect whether proc can be inlined:
-
-    - No local var assignments
-    - No return statements
-

--- a/TODO.md
+++ b/TODO.md
@@ -1,9 +1,49 @@
-## Immediate
+## Existing
 
-- Refactor proc_ext:
-  - remove all methods except for `render`, `apply`, `render_cache` from Proc.
-  - put them under `Papercraft` module.
-- Rework `render_cache` to take a key (instead of computing it from args).
+```ruby
+layout = ->(**) {
+  html {
+    body {
+      render_children(**)
+    }
+  }
+}
+
+page = layout.apply { |title:, **|
+  h1 title
+}
+
+page.render(title: 'foo')
+```
+
+## Alternative
+
+```ruby
+layout = ->(**) {
+  html {
+    body {
+      render_children(**)
+    }
+  }
+}
+
+page = Papercraft.apply(layout) { |title:, **|
+  h1 title
+}
+
+Papercraft.render(page, title: 'foo')
+```
+
+## Papercraft landing page example
+
+```ruby
+Papercraft.render(
+  -> {
+    h1 "Hello from Papercraft!"
+  }
+)
+#=> "<h1>Hello from Papercraft!</h1>"
+```
 
 ## API
 
@@ -25,3 +65,4 @@
 
     - No local var assignments
     - No return statements
+

--- a/examples/app.rb
+++ b/examples/app.rb
@@ -31,4 +31,4 @@ Content = ->(title:) {
   }
 }
 
-puts App.render(title: 'title parameter')
+puts Papercraft.html(App, title: 'title parameter')

--- a/examples/composition.rb
+++ b/examples/composition.rb
@@ -25,7 +25,9 @@ page = ->(title, items) {
   }
 }
 
-puts page.render('Hello from composed templates', [
-  { id: 1, text: 'foo', checked: false },
-  { id: 2, text: 'bar', checked: true }
-])
+puts Papercraft.html(page, 
+  'Hello from composed templates', [
+    { id: 1, text: 'foo', checked: false },
+    { id: 2, text: 'bar', checked: true }
+  ]
+)

--- a/examples/dashboard.rb
+++ b/examples/dashboard.rb
@@ -1,12 +1,6 @@
 # frozen_string_literal: true
 
-require 'bundler/inline'
-
-gemfile do
-  gem 'papercraft', path: '.'
-  gem 'benchmark-ips', '>= 2.14.0'
-  gem 'json'
-end
+require 'bundler/setup'
 
 require 'papercraft'
 require 'benchmark/ips'

--- a/examples/dashboard.rb
+++ b/examples/dashboard.rb
@@ -399,17 +399,17 @@ module Dashboard
 end
 
 
-html = Dashboard::Page.render
+html = Papercraft.html(Dashboard::Page)
 puts html
 puts
 puts format('Size: %.2gKB', html.bytesize.to_f / 1024)
 puts
-puts Dashboard::Page.compiled_code
+puts Papercraft.compiled_code(Dashboard::Page)
 puts
 
 Benchmark.ips do |x|
-  x.report('page') { Dashboard::Page.render }
-  x.report('cached') { Dashboard::Page.render_cached }
+  x.report('page') { Papercraft.html(Dashboard::Page) }
+  x.report('cached') { Papercraft.cache_html(Dashboard::Page, 'foo') }
 
   x.compare!(order: :baseline)
 end

--- a/examples/perf.rb
+++ b/examples/perf.rb
@@ -170,7 +170,7 @@ end
 
 class Renderer
   def render_papercraft_app
-    App.render(title: 'title from context')
+    Papercraft.render(App, title: 'title from context')
   end
 
   def render_phlex_app

--- a/examples/perf.rb
+++ b/examples/perf.rb
@@ -170,7 +170,7 @@ end
 
 class Renderer
   def render_papercraft_app
-    Papercraft.render(App, title: 'title from context')
+    Papercraft.html(App, title: 'title from context')
   end
 
   def render_phlex_app

--- a/examples/perf_code_gen.rb
+++ b/examples/perf_code_gen.rb
@@ -78,14 +78,14 @@ class Coalesced
     _b_ << "<!DOCTYPE html><html><body>#{
       Papercraft.render_emit_call(Header, title: title, &(->(_b_) {
         ; _b_ << "<button>1</button><button>2</button>"
-      }.compiled!))
+      }.__papercraft_compiled!))
       }#{
       Papercraft.render_emit_call(Content, title: title)
       }</body></html>";
     _b_
   rescue Exception => e
     raise e;
-  end.compiled!
+  end.__papercraft_compiled!
 
   Header = ->(_b_, title:, &__block__) do
     _b_ << "<header><h2 id=\"title\">#{
@@ -96,14 +96,14 @@ class Coalesced
     _b_
   rescue Exception => e
     raise e
-  end.compiled!
+  end.__papercraft_compiled!
 
   Content = ->(_b_, title:) do
     _b_ << "<article><h3>#{ERB::Escape.html_escape((title).to_s)}</h3><p>Hello, world!</p><div><a href=\"http://google.com/?a=1&b=2&c=3 4\"><h3>foo bar</h3></a><p>lorem ipsum</p></div></article>"
     _b_
   rescue Exception => e
     raise e
-  end.compiled!
+  end.__papercraft_compiled!
 end
 
 class Chunked
@@ -111,13 +111,13 @@ class Chunked
     _b_ << "<!DOCTYPE html><html><body>" <<
         Papercraft.render_emit_call(Header, title: title, &(->(_b_) {
         ; _b_ << "<button>1</button><button>2</button>"
-        }.compiled!)) <<
+        }.__papercraft_compiled!)) <<
         Papercraft.render_emit_call(Content, title: title) <<
         "</body></html>";
     _b_
   rescue Exception => e
     raise e;
-  end.compiled!
+  end.__papercraft_compiled!
 
   Header = ->(_b_, title:, &__block__) do
     _b_ << "<header><h2 id=\"title\">" <<
@@ -128,7 +128,7 @@ class Chunked
     _b_
   rescue Exception => e
     raise e
-  end.compiled!
+  end.__papercraft_compiled!
 
   Content = ->(_b_, title:) do
     _b_ << "<article><h3>" <<
@@ -137,7 +137,7 @@ class Chunked
     _b_
   rescue Exception => e
     raise e
-  end.compiled!
+  end.__papercraft_compiled!
 end
 
 class DirectInvocation
@@ -145,13 +145,13 @@ class DirectInvocation
     _b_ << "<!DOCTYPE html><html><body>"
     Header.compiled_proc.(_b_, title: title, &(->(_b_) {
       ; _b_ << "<button>1</button><button>2</button>"
-    }).compiled!)
+    }).__papercraft_compiled!)
     Content.compiled_proc.(_b_, title: title)
     _b_ << "</body></html>";
     _b_
   rescue Exception => e
     raise e;
-  end.compiled!
+  end.__papercraft_compiled!
 
   Header = ->(_b_, title:, &__block__) do
     _b_ << "<header><h2 id=\"title\">" <<
@@ -162,7 +162,7 @@ class DirectInvocation
     _b_
   rescue Exception => e
     raise e
-  end.compiled!
+  end.__papercraft_compiled!
 
   Content = ->(_b_, title:) do
     _b_ << "<article><h3>" <<
@@ -171,7 +171,7 @@ class DirectInvocation
     _b_
   rescue Exception => e
     raise e
-  end.compiled!
+  end.__papercraft_compiled!
 end
 
 class Inlined
@@ -189,7 +189,7 @@ class Inlined
     _b_
   rescue Exception => e
     raise e;
-  end.compiled!
+  end.__papercraft_compiled!
 
   # Header = ->(_b_, title:, &__block__) do
   #   _b_ << "<header><h2 id=\"title\">" <<
@@ -200,7 +200,7 @@ class Inlined
   #   _b_
   # rescue Exception => e
   #   raise e
-  # end.compiled!
+  # end.__papercraft_compiled!
 
   # Content = ->(_b_, title:) do
   #   _b_ << "<article><h3>" <<
@@ -209,7 +209,7 @@ class Inlined
   #   _b_
   # rescue Exception => e
   #   raise e
-  # end.compiled!
+  # end.__papercraft_compiled!
 end
 
 class NoYield
@@ -221,7 +221,7 @@ class NoYield
     _b_
   rescue Exception => e
     raise e;
-  end.compiled!
+  end.__papercraft_compiled!
 
   Header = ->(_b_, title:) do
     _b_ << "<header><h2 id=\"title\">" <<
@@ -230,7 +230,7 @@ class NoYield
     _b_
   rescue Exception => e
     raise e
-  end.compiled!
+  end.__papercraft_compiled!
 
   Content = ->(_b_, title:) do
     _b_ << "<article><h3>" <<
@@ -239,7 +239,7 @@ class NoYield
     _b_
   rescue Exception => e
     raise e
-  end.compiled!
+  end.__papercraft_compiled!
 end
 
 class NoYieldSeparate
@@ -251,7 +251,7 @@ class NoYieldSeparate
     _b_
   rescue Exception => e
     raise e;
-  end.compiled!
+  end.__papercraft_compiled!
 
   Header = ->(_b_, title:) do
     _b_ << "<header><h2 id=\"title\">"
@@ -260,7 +260,7 @@ class NoYieldSeparate
     _b_
   rescue Exception => e
     raise e
-  end.compiled!
+  end.__papercraft_compiled!
 
   Content = ->(_b_, title:) do
     _b_ << "<article><h3>"
@@ -269,7 +269,7 @@ class NoYieldSeparate
     _b_
   rescue Exception => e
     raise e
-  end.compiled!
+  end.__papercraft_compiled!
 end
 
 class NoRescue
@@ -277,11 +277,11 @@ class NoRescue
     _b_ << "<!DOCTYPE html><html><body>"
     Header.compiled_proc.(_b_, title: title, &(->(_b_) {
       ; _b_ << "<button>1</button><button>2</button>"
-    }).compiled!)
+    }).__papercraft_compiled!)
     Content.compiled_proc.(_b_, title: title)
     _b_ << "</body></html>";
     _b_
-  end.compiled!
+  end.__papercraft_compiled!
 
   Header = ->(_b_, title:, &__block__) do
     _b_ << "<header><h2 id=\"title\">" <<
@@ -290,14 +290,14 @@ class NoRescue
     (__block__ ? __block__.render_to_buffer(_b_) : raise(LocalJumpError, 'no block given (yield)'))
     _b_ << "</header>"
     _b_
-  end.compiled!
+  end.__papercraft_compiled!
 
   Content = ->(_b_, title:) do
     _b_ << "<article><h3>" <<
       ERB::Escape.html_escape((title).to_s) <<
       "</h3><p>Hello, world!</p><div><a href=\"http://google.com/?a=1&b=2&c=3 4\"><h3>foo bar</h3></a><p>lorem ipsum</p></div></article>"
     _b_
-  end.compiled!
+  end.__papercraft_compiled!
 end
 
 class Separate
@@ -305,13 +305,13 @@ class Separate
     _b_ << "<!DOCTYPE html><html><body>"
     _b_ << Papercraft.render_emit_call(Header, title: title, &(->(_b_) {
         ; _b_ << "<button>1</button><button>2</button>"
-        }.compiled!))
+        }.__papercraft_compiled!))
     _b_ << Papercraft.render_emit_call(Content, title: title)
     _b_ << "</body></html>";
     _b_
   rescue Exception => e
     raise e;
-  end.compiled!
+  end.__papercraft_compiled!
 
   Header = ->(_b_, title:, &__block__) do
     _b_ << "<header><h2 id=\"title\">"
@@ -322,7 +322,7 @@ class Separate
     _b_
   rescue Exception => e
     raise e
-  end.compiled!
+  end.__papercraft_compiled!
 
   Content = ->(_b_, title:) do
     _b_ << "<article><h3>"
@@ -331,7 +331,7 @@ class Separate
     _b_
   rescue Exception => e
     raise e
-  end.compiled!
+  end.__papercraft_compiled!
 end
 
 class CompiledERB
@@ -432,11 +432,11 @@ puts
 # puts
 
 puts "Papercraft baseline:"
-puts PapercraftBaseline::App.render(title: 'title')
+puts Papercraft.html(PapercraftBaseline::App, title: 'title')
 puts
 
 puts "Papercraft no yield:"
-puts PapercraftNoYield::App.render(title: 'title')
+puts Papercraft.html(PapercraftNoYield::App, title: 'title')
 puts
 
 cerb = CompiledERB.new
@@ -447,8 +447,8 @@ Benchmark.ips do |x|
 
   x.report("ERB") { cerb.render_app(title: 'title from context') }
   x.report("ERubi") { cerubi.render_app(title: 'title from context') }
-  x.report("papercraft baseline") { PapercraftBaseline::App.render(title: 'title from context') }
-  x.report("papercraft no yield") { PapercraftNoYield::App.render(title: 'title from context') }
+  x.report("papercraft baseline") { Papercraft.html(PapercraftBaseline::App, title: 'title from context') }
+  x.report("papercraft no yield") { Papercraft.html(PapercraftNoYield::App, title: 'title from context') }
 
   x.report("inlined") { Inlined::App.(+'', title: 'title from context') }
 

--- a/examples/simple.rb
+++ b/examples/simple.rb
@@ -9,10 +9,10 @@ t = ->(title:) {
   }
 }
 
-p t.ast
+p Papercraft.ast(t)
 puts
-puts t.compiled_code
+puts Papercraft.compiled_code(t)
 puts
-p t.source_map
+p Papercraft.source_map(t)
 puts
-puts t.render(title: 'Hello, world!')
+puts Papercraft.html(t, title: 'Hello, world!')

--- a/lib/papercraft.rb
+++ b/lib/papercraft.rb
@@ -168,7 +168,7 @@ module Papercraft
   # @return [Array<String>] source map
   def source_map(proc)
     loc = proc.source_location
-    fn = proc.__compiled__? ? loc.first : Papercraft::Compiler.source_location_to_fn(loc)
+    fn = proc.__papercraft_compiled? ? loc.first : Papercraft::Compiler.source_location_to_fn(loc)
     Papercraft::Compiler.source_map_store[fn]
   end
 
@@ -186,7 +186,7 @@ module Papercraft
   # @param mode [Symbol] compilation mode (:html, :xml)
   # @return [Proc] compiled proc
   def compile(proc, mode: :html)
-    Papercraft::Compiler.compile(proc, mode:).__compiled__!
+    Papercraft::Compiler.compile(proc, mode:).__papercraft_compiled!
   rescue Sirop::Error
     raise Papercraft::Error, "Can't compile eval'd template"
   end
@@ -197,7 +197,7 @@ module Papercraft
   # @return [String] HTML string
   def render(template, *a, **b, &c)
     template = template.proc if template.is_a?(Template)
-    template.__compiled_proc__.(+'', *a, **b, &c)
+    template.__papercraft_compiled_proc.(+'', *a, **b, &c)
   rescue Exception => e
     e.is_a?(Papercraft::Error) ? raise : raise(Papercraft.translate_backtrace(e))
   end
@@ -209,7 +209,7 @@ module Papercraft
   # @return [String] XML string
   def render_xml(template, *a, **b, &c)
     template = template.proc if template.is_a?(Template)
-    template.__compiled_proc__(mode: :xml).(+'', *a, **b, &c)
+    template.__papercraft_compiled_proc(mode: :xml).(+'', *a, **b, &c)
   rescue Exception => e
     e.is_a?(Papercraft::Error) ? raise : raise(Papercraft.translate_backtrace(e))
   end
@@ -226,16 +226,16 @@ module Papercraft
   # @return [Proc] applied proc
   def apply(template, *pos1, **kw1, &block)
     template = template.proc if template.is_a?(Template)
-    compiled = template.__compiled_proc__
-    c_compiled = block&.__compiled_proc__
+    compiled = template.__papercraft_compiled_proc
+    c_compiled = block&.__papercraft_compiled_proc
 
     ->(__buffer__, *pos2, **kw2, &block2) {
       c_proc = c_compiled && ->(__buffer__, *pos3, **kw3) {
         c_compiled.(__buffer__, *pos3, **kw3, &block2)
-      }.__compiled__!
+      }.__papercraft_compiled!
 
       compiled.(__buffer__, *pos1, *pos2, **kw1, **kw2, &c_proc)
-    }.__compiled__!
+    }.__papercraft_compiled!
   end
 
   # Caches and returns the rendered HTML for the template with the given
@@ -245,7 +245,7 @@ module Papercraft
   # @param key [any] Cache key
   # @return [String] HTML string
   def render_cache(template, key, *args, **kargs, &block)
-    template.__render_cache__[key] ||= render(template, *args, **kargs, &block)
+    template.__papercraft_render_cache[key] ||= render(template, *args, **kargs, &block)
   end
 
 end

--- a/lib/papercraft.rb
+++ b/lib/papercraft.rb
@@ -244,14 +244,19 @@ module Papercraft
   def apply(template, *pos1, **kw1, &block1)
     template = template.proc if template.is_a?(Template)
     compiled = template.__papercraft_compiled_proc
-    c_compiled = block1&.__papercraft_compiled_proc
+    block1_compiled = block1&.__papercraft_compiled_proc
 
     ->(__buffer__, *pos2, **kw2, &block2) {
-      compiled_block = c_compiled && ->(__buffer__, *pos3, **kw3) {
-        c_compiled.(__buffer__, *pos3, **kw3, &block2)
-      }.__papercraft_compiled!
-
-      compiled.(__buffer__, *pos1, *pos2, **kw1, **kw2, &compiled_block)
+      if block2
+        block2_compiled = block1_compiled ?
+          ->(__buffer__, *pos3, **kw3) {
+            block1_compiled.(__buffer__, *pos3, **kw3, &block2)
+          }.__papercraft_compiled! :
+          block2.__papercraft_compiled_proc
+        compiled.(__buffer__, *pos1, *pos2, **kw1, **kw2, &block2_compiled)
+      else
+        compiled.(__buffer__, *pos1, *pos2, **kw1, **kw2, &block1_compiled)
+      end
     }.__papercraft_compiled!
   end
 

--- a/lib/papercraft.rb
+++ b/lib/papercraft.rb
@@ -198,7 +198,7 @@ module Papercraft
   #
   # @param template [Proc] template proc
   # @return [String] HTML string
-  def render(template = nil, *pos, **kw, &block)
+  def html(template = nil, *pos, **kw, &block)
     if !template
       template = block
     elsif template.is_a?(Template)
@@ -210,7 +210,6 @@ module Papercraft
   rescue Exception => e
     e.is_a?(Papercraft::Error) ? raise : raise(Papercraft.translate_backtrace(e))
   end
-  alias_method :html, :render
 
   # Renders the given template to XML with the given arguments. The template can
   # be passed either as the first parameter, or as a block, if no parameter is
@@ -218,7 +217,7 @@ module Papercraft
   #
   # @param template [Proc] template proc
   # @return [String] XML string
-  def render_xml(template = nil, *pos, **kw, &block)
+  def xml(template = nil, *pos, **kw, &block)
     if !template
       template = block
     elsif template.is_a?(Template)
@@ -262,7 +261,17 @@ module Papercraft
   # @param template [Proc] template proc
   # @param key [any] Cache key
   # @return [String] HTML string
-  def render_cache(template, key, *args, **kargs, &block)
-    template.__papercraft_render_cache[key] ||= render(template, *args, **kargs, &block)
+  def cache_html(template, key, *, **, &)
+    template.__papercraft_render_cache[key] ||= html(template, *, **, &)
+  end
+
+  # Caches and returns the rendered XML for the template with the given
+  # arguments.
+  #
+  # @param template [Proc] template proc
+  # @param key [any] Cache key
+  # @return [String] XML string
+  def cache_xml(template, key, *, **, &)
+    template.__papercraft_render_cache[key] ||= xml(template, *, **, &)
   end
 end

--- a/lib/papercraft/compiler.rb
+++ b/lib/papercraft/compiler.rb
@@ -178,7 +178,7 @@ module Papercraft
       when Prism::BlockArgumentNode
         flush_html_parts!
         adjust_whitespace(node.block)
-        emit("; #{format_code(node.block.expression)}.__compiled_proc__.(__buffer__)")
+        emit("; #{format_code(node.block.expression)}.__papercraft_compiled_proc.(__buffer__)")
       end
 
       if node.inner_text
@@ -213,7 +213,7 @@ module Papercraft
         emit(format_code(node.call_node.receiver))
         emit('::')
       end
-      emit("#{node.call_node.name}.__compiled_proc__.(__buffer__")
+      emit("#{node.call_node.name}.__papercraft_compiled_proc.(__buffer__")
       if node.call_node.arguments
         emit(', ')
         visit(node.call_node.arguments)
@@ -229,17 +229,17 @@ module Papercraft
       args = node.call_node.arguments.arguments
       first_arg = args.first
 
-      block_embed = node.block && "&(->(__buffer__) #{format_code(node.block)}.__compiled__!)"
+      block_embed = node.block && "&(->(__buffer__) #{format_code(node.block)}.__papercraft_compiled!)"
       block_embed = ", #{block_embed}" if block_embed && node.call_node.arguments
 
       flush_html_parts!
       adjust_whitespace(node.location)
 
       if args.length == 1
-        emit("; #{format_code(first_arg)}.__compiled_proc__.(__buffer__#{block_embed})")
+        emit("; #{format_code(first_arg)}.__papercraft_compiled_proc.(__buffer__#{block_embed})")
       else
         args_code = format_code_comma_separated_nodes(args[1..])
-        emit("; #{format_code(first_arg)}.__compiled_proc__.(__buffer__, #{args_code}#{block_embed})")
+        emit("; #{format_code(first_arg)}.__papercraft_compiled_proc.(__buffer__, #{args_code}#{block_embed})")
       end
     end
 
@@ -336,7 +336,7 @@ module Papercraft
     def visit_extension_tag_node(node)
       flush_html_parts!
       adjust_whitespace(node.location)
-      emit("; Papercraft::Extensions[#{node.tag.inspect}].__compiled_proc__.(__buffer__")
+      emit("; Papercraft::Extensions[#{node.tag.inspect}].__papercraft_compiled_proc.(__buffer__")
       if node.call_node.arguments
         emit(', ')
         visit(node.call_node.arguments)
@@ -367,7 +367,7 @@ module Papercraft
         end
         block_params = block_params.empty? ? '' : ", #{block_params.join(', ')}"
 
-        emit(", &(proc { |__buffer__#{block_params}| #{block_body} }).__compiled__!")
+        emit(", &(proc { |__buffer__#{block_params}| #{block_body} }).__papercraft_compiled!")
       end
       emit(")")
     end
@@ -382,7 +382,7 @@ module Papercraft
       guard = @render_yield_used ?
         '' : "; raise(LocalJumpError, 'no block given (render_yield)') if !__block__"
       @render_yield_used = true
-      emit("#{guard}; __block__.__compiled_proc__.(__buffer__")
+      emit("#{guard}; __block__.__papercraft_compiled_proc.(__buffer__")
       if node.call_node.arguments
         emit(', ')
         visit(node.call_node.arguments)
@@ -398,7 +398,7 @@ module Papercraft
       flush_html_parts!
       adjust_whitespace(node.location)
       @render_children_used = true
-      emit("; __block__&.__compiled_proc__&.(__buffer__")
+      emit("; __block__&.__papercraft_compiled_proc&.(__buffer__")
       if node.call_node.arguments
         emit(', ')
         visit(node.call_node.arguments)
@@ -410,7 +410,7 @@ module Papercraft
       flush_html_parts!
       adjust_whitespace(node.location)
 
-      emit("; #{node.call_node.receiver.name}.__compiled_proc__.(__buffer__")
+      emit("; #{node.call_node.receiver.name}.__papercraft_compiled_proc.(__buffer__")
       if node.call_node.arguments
         emit(', ')
         visit(node.call_node.arguments)
@@ -418,7 +418,7 @@ module Papercraft
       if node.call_node.block
         emit(", &(->")
         visit(node.call_node.block)
-        emit(").__compiled_proc__")
+        emit(").__papercraft_compiled_proc")
       end
       emit(")")
     end

--- a/lib/papercraft/proc_ext.rb
+++ b/lib/papercraft/proc_ext.rb
@@ -8,16 +8,16 @@ module Papercraft
     # Returns true if proc is marked as compiled.
     #
     # @return [bool] is the proc marked as compiled
-    def __compiled__?
-      @__compiled__
+    def __papercraft_compiled?
+      @__papercraft_compiled
     end
 
     # Marks the proc as compiled, i.e. can render directly and takes a string
     # buffer as first argument.
     #
     # @return [self]
-    def __compiled__!
-      @__compiled__ = true
+    def __papercraft_compiled!
+      @__papercraft_compiled = true
       self
     end
 
@@ -26,15 +26,16 @@ module Papercraft
     #
     # @param mode [Symbol] compilation mode (:html, :xml)
     # @return [Proc] compiled proc or self
-    def __compiled_proc__(mode: :html)
-      @__compiled_proc__ ||= @__compiled__ ? self : Papercraft.compile(self, mode:)
+    def __papercraft_compiled_proc(mode: :html)
+      @__papercraft_compiled_proc ||= @__papercraft_compiled ?
+        self : Papercraft.compile(self, mode:)
     end
 
     # Returns the render cache for the proc.
     #
     # @return [Hash] cache hash
-    def __render_cache__
-      @__render_cache__ ||= {}
+    def __papercraft_render_cache
+      @__papercraft_render_cache ||= {}
     end
   end
 end

--- a/lib/papercraft/proc_ext.rb
+++ b/lib/papercraft/proc_ext.rb
@@ -21,7 +21,7 @@ module Papercraft
       self
     end
 
-    # Returns the compiled proc for the given proc. If marked as compiled, returns
+    # Returns the compiled proc for the proc. If marked as compiled, returns
     # self.
     #
     # @param mode [Symbol] compilation mode (:html, :xml)
@@ -30,54 +30,11 @@ module Papercraft
       @__compiled_proc__ ||= @__compiled__ ? self : Papercraft.compile(self, mode:)
     end
 
-    # Renders the proc to HTML with the given arguments.
+    # Returns the render cache for the proc.
     #
-    # @return [String] HTML string
-    def render(*a, **b, &c)
-      __compiled_proc__.(+'', *a, **b, &c)
-    rescue Exception => e
-      e.is_a?(Papercraft::Error) ? raise : raise(Papercraft.translate_backtrace(e))
-    end
-
-    # Renders the proc to XML with the given arguments.
-    #
-    # @return [String] XML string
-    def render_xml(*a, **b, &c)
-      __compiled_proc__(mode: :xml).(+'', *a, **b, &c)
-    rescue Exception => e
-      e.is_a?(Papercraft::Error) ? raise : raise(Papercraft.translate_backtrace(e))
-    end
-
-    # Returns a proc that applies the given arguments to the original proc. The
-    # returned proc calls the *compiled* form of the proc, merging the
-    # positional and keywords parameters passed to `#apply` with parameters
-    # passed to the applied proc. If a block is given, it is wrapped in a proc
-    # that passed merged parameters to the block.
-    #
-    # @param *pos1 [Array<any>] applied positional parameters
-    # @param **kw1 [Hash<any, any] applied keyword parameters
-    # @return [Proc] applied proc
-    def apply(*pos1, **kw1, &block)
-      compiled = __compiled_proc__
-      c_compiled = block&.__compiled_proc__
-
-      ->(__buffer__, *pos2, **kw2, &block2) {
-        c_proc = c_compiled && ->(__buffer__, *pos3, **kw3) {
-          c_compiled.(__buffer__, *pos3, **kw3, &block2)
-        }.__compiled__!
-
-        compiled.(__buffer__, *pos1, *pos2, **kw1, **kw2, &c_proc)
-      }.__compiled__!
-    end
-
-    # Caches and returns the rendered HTML for the template with the given
-    # arguments.
-    #
-    # @param key [any] Cache key
-    # @return [String] HTML string
-    def render_cache(key, *args, **kargs, &block)
-      @render_cache ||= {}
-      @render_cache[key] ||= render(*args, **kargs, &block)
+    # @return [Hash] cache hash
+    def __render_cache__
+      @__render_cache__ ||= {}
     end
   end
 end

--- a/lib/papercraft/template.rb
+++ b/lib/papercraft/template.rb
@@ -14,11 +14,11 @@ module Papercraft
     end
 
     def render(*, **, &)
-      (mode == :xml) ? @proc.render_xml(*, **, &) : @proc.render(*, **, &)
+      (mode == :xml) ? Papercraft.render_xml(@proc, *, **, &) : Papercraft.render(@proc, *, **, &)
     end
 
     def apply(*, **, &)
-      Template.new(@proc.apply(*, **, &), mode: @mode)
+      Template.new(Papercraft.apply(@proc, *, **, &), mode: @mode)
     end
 
     def __compiled_proc__

--- a/lib/papercraft/template.rb
+++ b/lib/papercraft/template.rb
@@ -8,21 +8,34 @@ module Papercraft
 
     # @param proc [Proc] template proc
     # @param mode [Symbol] mode (:html, :xml)
-    def initialize(proc, mode: :html)
-      @proc = proc
+    def initialize(proc = nil, mode: :html, &block)
+      @proc = proc || block
+      raise ArgumentError, "No template proc given" if !@proc
+
       @mode = mode
     end
 
+    # Renders the template.
+    #
+    # @return [String] generated HTML
     def render(*, **, &)
       (mode == :xml) ? Papercraft.render_xml(@proc, *, **, &) : Papercraft.render(@proc, *, **, &)
     end
+    alias_method :call, :render
 
+    # Applies the given parameters and block to the template, returning an
+    # applied template.
+    #
+    # @return [Papercraft::Template] applied template
     def apply(*, **, &)
       Template.new(Papercraft.apply(@proc, *, **, &), mode: @mode)
     end
 
-    def __compiled_proc__
-      @proc.__compiled_proc__(mode: @mode)
+    # Returns the compiled proc for the template.
+    #
+    # @return [Proc] compiled proc
+    def __papercraft_compiled_proc
+      @proc.__papercraft_compiled_proc(mode: @mode)
     end
   end
 end

--- a/lib/papercraft/template.rb
+++ b/lib/papercraft/template.rb
@@ -19,7 +19,7 @@ module Papercraft
     #
     # @return [String] generated HTML
     def render(*, **, &)
-      (mode == :xml) ? Papercraft.render_xml(@proc, *, **, &) : Papercraft.render(@proc, *, **, &)
+      (mode == :xml) ? Papercraft.xml(@proc, *, **, &) : Papercraft.html(@proc, *, **, &)
     end
     alias_method :call, :render
 

--- a/lib/papercraft/version.rb
+++ b/lib/papercraft/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Papercraft
-  VERSION = '2.24'
+  VERSION = '3.0'
 end

--- a/test/test_compiler.rb
+++ b/test/test_compiler.rb
@@ -25,7 +25,7 @@ class CompilerTest < Minitest::Test
         puts compiled_code
       end
 
-      assert_equal html, proc.render
+      assert_equal html, Papercraft.render(proc)
     end
   end
 end

--- a/test/test_compiler.rb
+++ b/test/test_compiler.rb
@@ -25,7 +25,7 @@ class CompilerTest < Minitest::Test
         puts compiled_code
       end
 
-      assert_equal html, Papercraft.render(proc)
+      assert_equal html, Papercraft.html(proc)
     end
   end
 end

--- a/test/test_html.rb
+++ b/test/test_html.rb
@@ -13,39 +13,39 @@ class HtmlTest < Minitest::Test
       text 'hi'
       hr
     }
-    assert_equal '<hr><input value="foo"><br>hi<hr>', Papercraft.render(h)
+    assert_equal '<hr><input value="foo"><br>hi<hr>', Papercraft.html(h)
   end
 
   def test_error_on_void_elements_with_block
     t = -> {
       hr { foo }
     }
-    assert_raises(Papercraft::Error) { Papercraft.render(t) }
+    assert_raises(Papercraft::Error) { Papercraft.html(t) }
     
     t = -> {
       input "foo"
     }
-    assert_raises(Papercraft::Error) { Papercraft.render(t) }
+    assert_raises(Papercraft::Error) { Papercraft.html(t) }
   end
 
   def test_html5
     assert_equal(
       '<!DOCTYPE html><html><div><h1>foobar</h1></div></html>',
-      Papercraft.render(-> { html5 { div { h1 'foobar' } } })
+      Papercraft.html(-> { html5 { div { h1 'foobar' } } })
     )
   end
 
   def test_html
     assert_equal(
       '<!DOCTYPE html><html><div><h1>foobar</h1></div></html>',
-      Papercraft.render(-> { html { div { h1 'foobar' } } })
+      Papercraft.html(-> { html { div { h1 'foobar' } } })
     )
   end
 
   def test_html_with_lang
     assert_equal(
       '<!DOCTYPE html><html lang="en"><div><h1>foobar</h1></div></html>',
-      Papercraft.render(-> { html(lang: "en") { div { h1 'foobar' } } })
+      Papercraft.html(-> { html(lang: "en") { div { h1 'foobar' } } })
     )
   end
 
@@ -55,7 +55,7 @@ class HtmlTest < Minitest::Test
     }
     assert_equal(
       '<link rel="stylesheet" href="/assets/style.css">',
-      Papercraft.render(html)
+      Papercraft.html(html)
     )
 
     html = -> {
@@ -63,7 +63,7 @@ class HtmlTest < Minitest::Test
     }
     assert_equal(
       '<link rel="stylesheet" href="/assets/style.css" media="print">',
-      Papercraft.render(html)
+      Papercraft.html(html)
     )
   end
 
@@ -76,7 +76,7 @@ class HtmlTest < Minitest::Test
     }
     assert_equal(
       "<style>* { color: red }\na & b { color: green }</style>",
-      Papercraft.render(html)
+      Papercraft.html(html)
     )
   end
 
@@ -88,7 +88,7 @@ class HtmlTest < Minitest::Test
     }
     assert_equal(
       "<script>if (a && b) c();</script>",
-      Papercraft.render(html)
+      Papercraft.html(html)
     )
   end
 
@@ -98,7 +98,7 @@ class HtmlTest < Minitest::Test
     }
     assert_equal(
       "<script src=\"/static/stuff.js\"></script>",
-      Papercraft.render(html)
+      Papercraft.html(html)
     )
   end
 
@@ -109,7 +109,7 @@ class HtmlTest < Minitest::Test
 
     assert_equal(
       '<span>me, myself &amp; I</span>',
-      Papercraft.render(html)
+      Papercraft.html(html)
     )
   end
 end
@@ -119,7 +119,7 @@ class RenderTest < Minitest::Test
     h = -> { div { p 'foo'; p 'bar' } }
     assert_equal(
       '<div><p>foo</p><p>bar</p></div>',
-      Papercraft.render(h)
+      Papercraft.html(h)
     )
   end
 end
@@ -128,41 +128,41 @@ class AttributesTest < Minitest::Test
   def test_attribute_encoding
     assert_equal(
       '<div class="blue and green"></div>',
-      Papercraft.render(-> { div class: 'blue and green' })
+      Papercraft.html(-> { div class: 'blue and green' })
     )
 
     assert_equal(
       '<div onclick="return doit();"></div>',
-      Papercraft.render(-> { div onclick: 'return doit();' })
+      Papercraft.html(-> { div onclick: 'return doit();' })
     )
 
     assert_equal(
       '<a href="/?q=a b"></a>',
-      Papercraft.render(-> { a href: '/?q=a b' })
+      Papercraft.html(-> { a href: '/?q=a b' })
     )
   end
 
   def test_valueless_attributes
     assert_equal(
       '<input type="checkbox" checked>',
-      Papercraft.render(-> { input type: 'checkbox', checked: true })
+      Papercraft.html(-> { input type: 'checkbox', checked: true })
     )
 
     assert_equal(
       '<input type="checkbox">',
-      Papercraft.render(-> { input type: 'checkbox', checked: false })
+      Papercraft.html(-> { input type: 'checkbox', checked: false })
     )
   end
 
   def test_array_attributes
     assert_equal(
       '<div class="foo bar"></div>',
-      Papercraft.render(-> { div class: [:foo, :bar] })
+      Papercraft.html(-> { div class: [:foo, :bar] })
     )
 
     assert_equal(
       '<div class="foo  bar"></div>',
-      Papercraft.render(-> { div class: [:foo, nil, 'bar'] })
+      Papercraft.html(-> { div class: [:foo, nil, 'bar'] })
     )
   end
 end
@@ -171,54 +171,54 @@ class DynamicTagMethodTest < Minitest::Test
   def test_that_dynamic_tag_method_accepts_no_arguments
     assert_equal(
       '<div></div>',
-      Papercraft.render(-> { div() })
+      Papercraft.html(-> { div() })
     )
   end
 
   def test_that_dynamic_tag_method_accepts_text_argument
     assert_equal(
       '<p>lorem ipsum</p>',
-      Papercraft.render(-> { p "lorem ipsum" })
+      Papercraft.html(-> { p "lorem ipsum" })
     )
   end
 
   def test_that_dynamic_tag_method_accepts_non_string_text_argument
     assert_equal(
       '<p>lorem</p>',
-      Papercraft.render(-> { p :lorem })
+      Papercraft.html(-> { p :lorem })
     )
   end
 
   def test_that_dynamic_tag_method_escapes_string_text_argument
     assert_equal(
       '<p>lorem &amp; ipsum</p>',
-      Papercraft.render(-> { p 'lorem & ipsum' })
+      Papercraft.html(-> { p 'lorem & ipsum' })
     )
   end
 
   def test_dynamic_tag_underscore_to_hyphen_conversion
     assert_equal(
       '<my-nifty-tag>foo</my-nifty-tag>',
-      Papercraft.render(-> { my_nifty_tag 'foo' })
+      Papercraft.html(-> { my_nifty_tag 'foo' })
     )
 
     assert_equal(
       '<my-nifty-tag></my-nifty-tag>',
-      Papercraft.render(-> { my_nifty_tag })
+      Papercraft.html(-> { my_nifty_tag })
     )
   end
 
   def test_that_dynamic_tag_method_accepts_text_and_attributes
     assert_equal(
       '<p class="hi">lorem ipsum</p>',
-      Papercraft.render(-> { p "lorem ipsum", class: 'hi' })
+      Papercraft.html(-> { p "lorem ipsum", class: 'hi' })
     )
   end
 
   def test_dynamic_tag_attribute_underscore_to_hyphen_conversion
     assert_equal(
       '<p data-foo="bar">hello</p>',
-      Papercraft.render(-> { p 'hello', data_foo: 'bar' })
+      Papercraft.html(-> { p 'hello', data_foo: 'bar' })
     )
   end
 
@@ -227,14 +227,14 @@ class DynamicTagMethodTest < Minitest::Test
 
     assert_equal(
       '<p><a href="/">foo</a></p>',
-      Papercraft.render(-> { p(&a) })
+      Papercraft.html(-> { p(&a) })
     )
   end
 
   def test_that_dynamic_tag_method_accepts_block
     assert_equal(
       '<div><p><a></a></p></div>',
-      Papercraft.render(-> { div { p { a() } } })
+      Papercraft.html(-> { div { p { a() } } })
     )
   end
 end
@@ -243,54 +243,54 @@ class TagMethodTest < Minitest::Test
   def test_that_tag_method_accepts_no_arguments
     assert_equal(
       '<div></div>',
-      Papercraft.render(-> { tag(:div) })
+      Papercraft.html(-> { tag(:div) })
     )
   end
 
   def test_that_tag_method_accepts_text_argument
     assert_equal(
       '<p>lorem ipsum</p>',
-      Papercraft.render(-> { tag :p, "lorem ipsum" })
+      Papercraft.html(-> { tag :p, "lorem ipsum" })
     )
   end
 
   def test_that_tag_method_accepts_non_string_text_argument
     assert_equal(
       '<p>lorem</p>',
-      Papercraft.render(-> { tag :p, :lorem })
+      Papercraft.html(-> { tag :p, :lorem })
     )
   end
 
   def test_that_tag_method_escapes_string_text_argument
     assert_equal(
       '<p>lorem &amp; ipsum</p>',
-      Papercraft.render(-> { tag :p, 'lorem & ipsum' })
+      Papercraft.html(-> { tag :p, 'lorem & ipsum' })
     )
   end
 
   def test_tag_underscore_to_hyphen_conversion
     assert_equal(
       '<my-nifty-tag>foo</my-nifty-tag>',
-      Papercraft.render(-> { tag :my_nifty_tag, 'foo' })
+      Papercraft.html(-> { tag :my_nifty_tag, 'foo' })
     )
 
     assert_equal(
       '<my-nifty-tag></my-nifty-tag>',
-      Papercraft.render(-> { tag :my_nifty_tag })
+      Papercraft.html(-> { tag :my_nifty_tag })
     )
   end
 
   def test_that_tag_method_accepts_text_and_attributes
     assert_equal(
       '<p class="hi">lorem ipsum</p>',
-      Papercraft.render(-> { tag :p, "lorem ipsum", class: 'hi' })
+      Papercraft.html(-> { tag :p, "lorem ipsum", class: 'hi' })
     )
   end
 
   def test_attribute_underscore_to_hyphen_conversion
     assert_equal(
       '<p data-foo="bar">hello</p>',
-      Papercraft.render(-> { tag :p, 'hello', data_foo: 'bar' })
+      Papercraft.html(-> { tag :p, 'hello', data_foo: 'bar' })
     )
   end
 
@@ -299,14 +299,14 @@ class TagMethodTest < Minitest::Test
 
     assert_equal(
       '<p><a href="/">foo</a></p>',
-      Papercraft.render(-> { tag :p, &a })
+      Papercraft.html(-> { tag :p, &a })
     )
   end
 
   def test_that_tag_method_accepts_block
     assert_equal(
       '<div><p><a></a></p></div>',
-      Papercraft.render(-> { tag(:div) { tag(:p) { tag :a } } })
+      Papercraft.html(-> { tag(:div) { tag(:p) { tag :a } } })
     )
   end
 end
@@ -318,31 +318,31 @@ class SubTemplateTest < Minitest::Test
 
     assert_equal(
       'foobar',
-      Papercraft.render(-> { render block })
+      Papercraft.html(-> { render block })
     )
   end
 
   def test_that_raw_accepts_string
     assert_equal(
       '<div>foobar</div>',
-      Papercraft.render(-> { div { raw 'foobar' } })
+      Papercraft.html(-> { div { raw 'foobar' } })
     )
   end
 
   def test_that_raw_doesnt_escape_string
     assert_equal(
       '<div>foo&bar</div>',
-      Papercraft.render(-> { div { raw 'foo&bar' } })
+      Papercraft.html(-> { div { raw 'foo&bar' } })
     )
   end
 
   def test_render_yield
     r = -> { body { render_yield } }
-    assert_raises { Papercraft.render(r, foo: 'bar') }
+    assert_raises { Papercraft.html(r, foo: 'bar') }
 
     assert_equal(
       '<body><p>foo</p><hr></body>',
-      Papercraft.render(r) { p 'foo'; hr; }
+      Papercraft.html(r) { p 'foo'; hr; }
     )
   end
 
@@ -351,7 +351,7 @@ class SubTemplateTest < Minitest::Test
     inner = -> { p 'foo' }
     assert_equal(
       '<body><div id="content"><p>foo</p></div></body>',
-      Papercraft.render(outer, &inner)
+      Papercraft.html(outer, &inner)
     )
   end
 
@@ -371,7 +371,7 @@ class SubTemplateTest < Minitest::Test
     }
 
     assert_equal '<ul><li><card><span>foo</span></card></li><li><card><span>bar</span></card></li></ul>',
-      Papercraft.render(ulist, %w{foo bar}, &item_card)
+      Papercraft.html(ulist, %w{foo bar}, &item_card)
   end
 end
 
@@ -380,7 +380,7 @@ class ScopeTest < Minitest::Test
     text = 'foobar'
     assert_equal(
       '<p>foobar</p>',
-      Papercraft.render(-> { p text })
+      Papercraft.html(-> { p text })
     )
   end
 end
@@ -400,7 +400,7 @@ class DeferTest < Minitest::Test
       }
     }
 
-    assert_equal "<div><h1>bar</h1></div>", Papercraft.render(html)
+    assert_equal "<div><h1>bar</h1></div>", Papercraft.html(html)
   end
 
   def test_deferred_title
@@ -415,7 +415,7 @@ class DeferTest < Minitest::Test
       }
     }
 
-    html = Papercraft.render(layout) {
+    html = Papercraft.html(layout) {
       @title = 'My super page'
       h1 'foo'
     }
@@ -449,7 +449,7 @@ class DeferTest < Minitest::Test
       p 'Welcome to the awesome user form'
     }
 
-    html = Papercraft.render(layout, &user_form)
+    html = Papercraft.html(layout, &user_form)
 
     assert_equal "<!DOCTYPE html><html><head><title>Awesome user form</title></head><body><form><h3>Syntax error!</h3><p>Welcome to the awesome user form</p></form></body></html>",
       html

--- a/test/test_html.rb
+++ b/test/test_html.rb
@@ -13,39 +13,39 @@ class HtmlTest < Minitest::Test
       text 'hi'
       hr
     }
-    assert_equal '<hr><input value="foo"><br>hi<hr>', h.render
+    assert_equal '<hr><input value="foo"><br>hi<hr>', Papercraft.render(h)
   end
 
   def test_error_on_void_elements_with_block
     t = -> {
       hr { foo }
     }
-    assert_raises(Papercraft::Error) { t.render }
+    assert_raises(Papercraft::Error) { Papercraft.render(t) }
     
     t = -> {
       input "foo"
     }
-    assert_raises(Papercraft::Error) { t.render }
+    assert_raises(Papercraft::Error) { Papercraft.render(t) }
   end
 
   def test_html5
     assert_equal(
       '<!DOCTYPE html><html><div><h1>foobar</h1></div></html>',
-      -> { html5 { div { h1 'foobar' } } }.render
+      Papercraft.render(-> { html5 { div { h1 'foobar' } } })
     )
   end
 
   def test_html
     assert_equal(
       '<!DOCTYPE html><html><div><h1>foobar</h1></div></html>',
-      -> { html { div { h1 'foobar' } } }.render
+      Papercraft.render(-> { html { div { h1 'foobar' } } })
     )
   end
 
   def test_html_with_lang
     assert_equal(
       '<!DOCTYPE html><html lang="en"><div><h1>foobar</h1></div></html>',
-      -> { html(lang: "en") { div { h1 'foobar' } } }.render
+      Papercraft.render(-> { html(lang: "en") { div { h1 'foobar' } } })
     )
   end
 
@@ -55,7 +55,7 @@ class HtmlTest < Minitest::Test
     }
     assert_equal(
       '<link rel="stylesheet" href="/assets/style.css">',
-      html.render
+      Papercraft.render(html)
     )
 
     html = -> {
@@ -63,7 +63,7 @@ class HtmlTest < Minitest::Test
     }
     assert_equal(
       '<link rel="stylesheet" href="/assets/style.css" media="print">',
-      html.render
+      Papercraft.render(html)
     )
   end
 
@@ -76,7 +76,7 @@ class HtmlTest < Minitest::Test
     }
     assert_equal(
       "<style>* { color: red }\na & b { color: green }</style>",
-      html.render
+      Papercraft.render(html)
     )
   end
 
@@ -88,7 +88,7 @@ class HtmlTest < Minitest::Test
     }
     assert_equal(
       "<script>if (a && b) c();</script>",
-      html.render
+      Papercraft.render(html)
     )
   end
 
@@ -98,7 +98,7 @@ class HtmlTest < Minitest::Test
     }
     assert_equal(
       "<script src=\"/static/stuff.js\"></script>",
-      html.render
+      Papercraft.render(html)
     )
   end
 
@@ -109,7 +109,7 @@ class HtmlTest < Minitest::Test
 
     assert_equal(
       '<span>me, myself &amp; I</span>',
-      html.render
+      Papercraft.render(html)
     )
   end
 end
@@ -119,7 +119,7 @@ class RenderTest < Minitest::Test
     h = -> { div { p 'foo'; p 'bar' } }
     assert_equal(
       '<div><p>foo</p><p>bar</p></div>',
-      h.render
+      Papercraft.render(h)
     )
   end
 end
@@ -128,41 +128,41 @@ class AttributesTest < Minitest::Test
   def test_attribute_encoding
     assert_equal(
       '<div class="blue and green"></div>',
-      -> { div class: 'blue and green' }.render
+      Papercraft.render(-> { div class: 'blue and green' })
     )
 
     assert_equal(
       '<div onclick="return doit();"></div>',
-      -> { div onclick: 'return doit();' }.render
+      Papercraft.render(-> { div onclick: 'return doit();' })
     )
 
     assert_equal(
       '<a href="/?q=a b"></a>',
-      -> { a href: '/?q=a b' }.render
+      Papercraft.render(-> { a href: '/?q=a b' })
     )
   end
 
   def test_valueless_attributes
     assert_equal(
       '<input type="checkbox" checked>',
-      -> { input type: 'checkbox', checked: true }.render
+      Papercraft.render(-> { input type: 'checkbox', checked: true })
     )
 
     assert_equal(
       '<input type="checkbox">',
-      -> { input type: 'checkbox', checked: false }.render
+      Papercraft.render(-> { input type: 'checkbox', checked: false })
     )
   end
 
   def test_array_attributes
     assert_equal(
       '<div class="foo bar"></div>',
-      -> { div class: [:foo, :bar] }.render
+      Papercraft.render(-> { div class: [:foo, :bar] })
     )
 
     assert_equal(
       '<div class="foo  bar"></div>',
-      -> { div class: [:foo, nil, 'bar'] }.render
+      Papercraft.render(-> { div class: [:foo, nil, 'bar'] })
     )
   end
 end
@@ -171,54 +171,54 @@ class DynamicTagMethodTest < Minitest::Test
   def test_that_dynamic_tag_method_accepts_no_arguments
     assert_equal(
       '<div></div>',
-      -> { div() }.render
+      Papercraft.render(-> { div() })
     )
   end
 
   def test_that_dynamic_tag_method_accepts_text_argument
     assert_equal(
       '<p>lorem ipsum</p>',
-      -> { p "lorem ipsum" }.render
+      Papercraft.render(-> { p "lorem ipsum" })
     )
   end
 
   def test_that_dynamic_tag_method_accepts_non_string_text_argument
     assert_equal(
       '<p>lorem</p>',
-      -> { p :lorem }.render
+      Papercraft.render(-> { p :lorem })
     )
   end
 
   def test_that_dynamic_tag_method_escapes_string_text_argument
     assert_equal(
       '<p>lorem &amp; ipsum</p>',
-      -> { p 'lorem & ipsum' }.render
+      Papercraft.render(-> { p 'lorem & ipsum' })
     )
   end
 
   def test_dynamic_tag_underscore_to_hyphen_conversion
     assert_equal(
       '<my-nifty-tag>foo</my-nifty-tag>',
-      -> { my_nifty_tag 'foo' }.render
+      Papercraft.render(-> { my_nifty_tag 'foo' })
     )
 
     assert_equal(
       '<my-nifty-tag></my-nifty-tag>',
-      -> { my_nifty_tag }.render
+      Papercraft.render(-> { my_nifty_tag })
     )
   end
 
   def test_that_dynamic_tag_method_accepts_text_and_attributes
     assert_equal(
       '<p class="hi">lorem ipsum</p>',
-      -> { p "lorem ipsum", class: 'hi' }.render
+      Papercraft.render(-> { p "lorem ipsum", class: 'hi' })
     )
   end
 
   def test_dynamic_tag_attribute_underscore_to_hyphen_conversion
     assert_equal(
       '<p data-foo="bar">hello</p>',
-      -> { p 'hello', data_foo: 'bar' }.render
+      Papercraft.render(-> { p 'hello', data_foo: 'bar' })
     )
   end
 
@@ -227,14 +227,14 @@ class DynamicTagMethodTest < Minitest::Test
 
     assert_equal(
       '<p><a href="/">foo</a></p>',
-      -> { p(&a) }.render
+      Papercraft.render(-> { p(&a) })
     )
   end
 
   def test_that_dynamic_tag_method_accepts_block
     assert_equal(
       '<div><p><a></a></p></div>',
-      -> { div { p { a() } } }.render
+      Papercraft.render(-> { div { p { a() } } })
     )
   end
 end
@@ -243,54 +243,54 @@ class TagMethodTest < Minitest::Test
   def test_that_tag_method_accepts_no_arguments
     assert_equal(
       '<div></div>',
-      -> { tag(:div) }.render
+      Papercraft.render(-> { tag(:div) })
     )
   end
 
   def test_that_tag_method_accepts_text_argument
     assert_equal(
       '<p>lorem ipsum</p>',
-      -> { tag :p, "lorem ipsum" }.render
+      Papercraft.render(-> { tag :p, "lorem ipsum" })
     )
   end
 
   def test_that_tag_method_accepts_non_string_text_argument
     assert_equal(
       '<p>lorem</p>',
-      -> { tag :p, :lorem }.render
+      Papercraft.render(-> { tag :p, :lorem })
     )
   end
 
   def test_that_tag_method_escapes_string_text_argument
     assert_equal(
       '<p>lorem &amp; ipsum</p>',
-      -> { tag :p, 'lorem & ipsum' }.render
+      Papercraft.render(-> { tag :p, 'lorem & ipsum' })
     )
   end
 
   def test_tag_underscore_to_hyphen_conversion
     assert_equal(
       '<my-nifty-tag>foo</my-nifty-tag>',
-      -> { tag :my_nifty_tag, 'foo' }.render
+      Papercraft.render(-> { tag :my_nifty_tag, 'foo' })
     )
 
     assert_equal(
       '<my-nifty-tag></my-nifty-tag>',
-      -> { tag :my_nifty_tag }.render
+      Papercraft.render(-> { tag :my_nifty_tag })
     )
   end
 
   def test_that_tag_method_accepts_text_and_attributes
     assert_equal(
       '<p class="hi">lorem ipsum</p>',
-      -> { tag :p, "lorem ipsum", class: 'hi' }.render
+      Papercraft.render(-> { tag :p, "lorem ipsum", class: 'hi' })
     )
   end
 
   def test_attribute_underscore_to_hyphen_conversion
     assert_equal(
       '<p data-foo="bar">hello</p>',
-      -> { tag :p, 'hello', data_foo: 'bar' }.render
+      Papercraft.render(-> { tag :p, 'hello', data_foo: 'bar' })
     )
   end
 
@@ -299,14 +299,14 @@ class TagMethodTest < Minitest::Test
 
     assert_equal(
       '<p><a href="/">foo</a></p>',
-      -> { tag :p, &a }.render
+      Papercraft.render(-> { tag :p, &a })
     )
   end
 
   def test_that_tag_method_accepts_block
     assert_equal(
       '<div><p><a></a></p></div>',
-      -> { tag(:div) { tag(:p) { tag :a } } }.render
+      Papercraft.render(-> { tag(:div) { tag(:p) { tag :a } } })
     )
   end
 end
@@ -318,31 +318,31 @@ class SubTemplateTest < Minitest::Test
 
     assert_equal(
       'foobar',
-      -> { render block }.render
+      Papercraft.render(-> { render block })
     )
   end
 
   def test_that_raw_accepts_string
     assert_equal(
       '<div>foobar</div>',
-      -> { div { raw 'foobar' } }.render
+      Papercraft.render(-> { div { raw 'foobar' } })
     )
   end
 
   def test_that_raw_doesnt_escape_string
     assert_equal(
       '<div>foo&bar</div>',
-      -> { div { raw 'foo&bar' } }.render
+      Papercraft.render(-> { div { raw 'foo&bar' } })
     )
   end
 
   def test_render_yield
     r = -> { body { render_yield } }
-    assert_raises { r.render(foo: 'bar') }
+    assert_raises { Papercraft.render(r, foo: 'bar') }
 
     assert_equal(
       '<body><p>foo</p><hr></body>',
-      r.render { p 'foo'; hr; }
+      Papercraft.render(r) { p 'foo'; hr; }
     )
   end
 
@@ -351,7 +351,7 @@ class SubTemplateTest < Minitest::Test
     inner = -> { p 'foo' }
     assert_equal(
       '<body><div id="content"><p>foo</p></div></body>',
-      outer.render(&inner)
+      Papercraft.render(outer, &inner)
     )
   end
 
@@ -370,7 +370,8 @@ class SubTemplateTest < Minitest::Test
       }
     }
 
-    assert_equal '<ul><li><card><span>foo</span></card></li><li><card><span>bar</span></card></li></ul>', ulist.render(%w{foo bar}, &item_card)
+    assert_equal '<ul><li><card><span>foo</span></card></li><li><card><span>bar</span></card></li></ul>',
+      Papercraft.render(ulist, %w{foo bar}, &item_card)
   end
 end
 
@@ -379,7 +380,7 @@ class ScopeTest < Minitest::Test
     text = 'foobar'
     assert_equal(
       '<p>foobar</p>',
-      -> { p text }.render
+      Papercraft.render(-> { p text })
     )
   end
 end
@@ -399,7 +400,7 @@ class DeferTest < Minitest::Test
       }
     }
 
-    assert_equal "<div><h1>bar</h1></div>", html.render
+    assert_equal "<div><h1>bar</h1></div>", Papercraft.render(html)
   end
 
   def test_deferred_title
@@ -414,7 +415,7 @@ class DeferTest < Minitest::Test
       }
     }
 
-    html = layout.render {
+    html = Papercraft.render(layout) {
       @title = 'My super page'
       h1 'foo'
     }
@@ -441,14 +442,14 @@ class DeferTest < Minitest::Test
       }
     }
 
-    user_form = form.apply {
+    user_form = Papercraft.apply(form) {
       @title = 'Awesome user form'
       @error_message = 'Syntax error!'
 
       p 'Welcome to the awesome user form'
     }
 
-    html = layout.render(&user_form)
+    html = Papercraft.render(layout, &user_form)
 
     assert_equal "<!DOCTYPE html><html><head><title>Awesome user form</title></head><body><form><h3>Syntax error!</h3><p>Welcome to the awesome user form</p></form></body></html>",
       html

--- a/test/test_markdown.rb
+++ b/test/test_markdown.rb
@@ -8,21 +8,21 @@ class MarkdownTest < Minitest::Test
   def test_basic_markdown
     templ = ->(md) { body { markdown(md) } }
     assert_equal "<body><h1 id=\"hi\">hi</h1>\n</body>",
-      Papercraft.render(templ, '# hi')
+      Papercraft.html(templ, '# hi')
 
     assert_equal "<body><p>Hello, <em>emphasis</em>.</p>\n</body>",
-      Papercraft.render(templ, 'Hello, *emphasis*.')
+      Papercraft.html(templ, 'Hello, *emphasis*.')
   end
 
   def test_markdown_opts
     templ = ->(md) { markdown(md, auto_ids: false) }
     assert_equal "<h1>hi</h1>\n",
-      Papercraft.render(templ, '# hi')
+      Papercraft.html(templ, '# hi')
 
     templ = ->(md) { markdown(md) }
     Papercraft.default_kramdown_options[:auto_ids] = false
     assert_equal "<h1>hi</h1>\n",
-      Papercraft.render(templ, '# hi')
+      Papercraft.html(templ, '# hi')
   ensure
     Papercraft.default_kramdown_options.delete(:auto_ids)
   end
@@ -30,13 +30,13 @@ class MarkdownTest < Minitest::Test
   def test_markdown_with_inline_code
     templ = ->(md) { markdown(md) }
     assert_equal "<p>Im calling <code>templ.render</code>.</p>\n",
-      Papercraft.render(templ, 'I''m calling `templ.render`.')
+      Papercraft.html(templ, 'I''m calling `templ.render`.')
   end
 
   def test_markdown_with_code_block
     templ = ->(md) { markdown(md) }
     assert_equal "<p>before</p>\n\n<div class=\"language-ruby highlighter-rouge\"><div class=\"highlight\"><pre class=\"highlight\"><code><span class=\"k\">def</span> <span class=\"nf\">foo</span><span class=\"p\">;</span> <span class=\"k\">end</span>\n</code></pre></div></div>\n\n<p>after</p>\n",
-      Papercraft.render(templ, "before\n\n```ruby\ndef foo; end\n```\n\nafter")
+      Papercraft.html(templ, "before\n\n```ruby\ndef foo; end\n```\n\nafter")
   end
 
   def test_papercraft_markdown_method

--- a/test/test_markdown.rb
+++ b/test/test_markdown.rb
@@ -8,21 +8,21 @@ class MarkdownTest < Minitest::Test
   def test_basic_markdown
     templ = ->(md) { body { markdown(md) } }
     assert_equal "<body><h1 id=\"hi\">hi</h1>\n</body>",
-      templ.render('# hi')
+      Papercraft.render(templ, '# hi')
 
     assert_equal "<body><p>Hello, <em>emphasis</em>.</p>\n</body>",
-      templ.render('Hello, *emphasis*.')
+      Papercraft.render(templ, 'Hello, *emphasis*.')
   end
 
   def test_markdown_opts
     templ = ->(md) { markdown(md, auto_ids: false) }
     assert_equal "<h1>hi</h1>\n",
-      templ.render('# hi')
+      Papercraft.render(templ, '# hi')
 
     templ = ->(md) { markdown(md) }
     Papercraft.default_kramdown_options[:auto_ids] = false
     assert_equal "<h1>hi</h1>\n",
-      templ.render('# hi')
+      Papercraft.render(templ, '# hi')
   ensure
     Papercraft.default_kramdown_options.delete(:auto_ids)
   end
@@ -30,13 +30,13 @@ class MarkdownTest < Minitest::Test
   def test_markdown_with_inline_code
     templ = ->(md) { markdown(md) }
     assert_equal "<p>Im calling <code>templ.render</code>.</p>\n",
-      templ.render('I''m calling `templ.render`.')
+      Papercraft.render(templ, 'I''m calling `templ.render`.')
   end
 
   def test_markdown_with_code_block
     templ = ->(md) { markdown(md) }
     assert_equal "<p>before</p>\n\n<div class=\"language-ruby highlighter-rouge\"><div class=\"highlight\"><pre class=\"highlight\"><code><span class=\"k\">def</span> <span class=\"nf\">foo</span><span class=\"p\">;</span> <span class=\"k\">end</span>\n</code></pre></div></div>\n\n<p>after</p>\n",
-      templ.render("before\n\n```ruby\ndef foo; end\n```\n\nafter")
+      Papercraft.render(templ, "before\n\n```ruby\ndef foo; end\n```\n\nafter")
   end
 
   def test_papercraft_markdown_method

--- a/test/test_papercraft.rb
+++ b/test/test_papercraft.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require 'bundler/setup'
+require 'minitest/autorun'
+require 'papercraft'
+
+class PapercraftRenderTest < Minitest::Test
+  def test_papercraft_render_with_block
+    html = Papercraft.render {
+      h1 "foo"
+    }
+    assert_equal '<h1>foo</h1>', html
+  end
+
+  def test_papercraft_render_with_template
+    t = -> {
+      h1 "foo"
+    }
+    html = Papercraft.render(t)    
+    assert_equal '<h1>foo</h1>', html
+  end
+
+  def test_papercraft_render_template_with_parameters
+    t = ->(name) {
+      h1 name
+    }
+    html = Papercraft.render(t, 'bar')    
+    assert_equal '<h1>bar</h1>', html
+
+    t = ->(name:) {
+      h1 name
+    }
+    assert_raises(ArgumentError) { Papercraft.render(t, 'bar') }
+    html = Papercraft.render(t, name: 'bar')
+    assert_equal '<h1>bar</h1>', html
+  end
+
+  def test_papercraft_render_template_with_block
+    t = ->(name:) {
+      div {
+        render_yield(name:)
+      }
+    }
+    assert_raises(LocalJumpError) { Papercraft.render(t, name: 'bar') }
+    html = Papercraft.render(t, name: 'bar') { |name:| h2 name }
+    assert_equal '<div><h2>bar</h2></div>', html 
+  end
+
+  def test_papercraft_render_xml
+    t = ->(name:) {
+      link name
+    }
+    xml = Papercraft.render_xml(t, name: 'foo')
+    assert_equal '<link>foo</link>', xml
+
+    xml = Papercraft.render_xml { link 'bar' }
+    assert_equal '<link>bar</link>', xml
+  end
+
+  def test_papercraft_extension
+    Papercraft.extension(
+      __foo_bar__: -> { h1 "foobar" }
+    )
+    html = Papercraft.render { __foo_bar__ }
+    assert_equal '<h1>foobar</h1>', html
+  end
+
+  def test_papercraft_underscores_to_dashes
+    assert_equal "abc-def", Papercraft.underscores_to_dashes("abc_def")
+    assert_equal "abc-def", Papercraft.underscores_to_dashes(:abc_def)
+  end
+
+  def test_papercraft_format_tag_attrs
+    assert_equal 'abc="def"', Papercraft.format_tag_attrs(abc: "def")
+    assert_equal 'abc="def" ghi="jkl"', Papercraft.format_tag_attrs(
+      abc: "def", ghi: "jkl"
+    )
+    assert_equal 'abc-def="ghi"', Papercraft.format_tag_attrs(
+      abc_def: "ghi"
+    )
+    assert_equal 'abc="def" ghi', Papercraft.format_tag_attrs(
+      abc: "def", ghi: true, jkl: false
+    )
+  end
+
+  def test_papercraft_markdown_doc
+    doc = Papercraft.markdown_doc("# foo")
+    assert_kind_of Kramdown::Document, doc
+  end
+
+  def test_papercraft_markdown
+    html = Papercraft.markdown("# foo")
+    assert_equal '<h1 id="foo">foo</h1>', html.chomp
+  end
+end

--- a/test/test_papercraft.rb
+++ b/test/test_papercraft.rb
@@ -134,4 +134,33 @@ class PapercraftRenderTest < Minitest::Test
     assert_equal "<link>bar</link>", Papercraft.cache_xml(t, 'bar', 'bar')
     assert_equal 2, count
   end
+
+  def test_papercraft_apply_params
+    t = ->(a, b, c:, d:) {
+      hr(a => b, c => d)
+    }
+    a = Papercraft.apply(t, 'foo', 'bar', c: 'baz', d: 42)
+    assert_equal '<hr foo="bar" baz="42">', Papercraft.html(a)
+  end
+
+  def test_papercraft_apply_with_block
+    t = ->(foo:) { div { render_yield(bar: foo) } }
+    a = Papercraft.apply(t, foo: 'baz') { |bar:| h1 bar }
+    assert_equal "<div><h1>baz</h1></div>", Papercraft.html(a)
+  end
+
+  def test_papercraft_apply_with_block_nested_render_yield
+    t = ->(foo:) { div { render_yield(bar: foo) } }
+    a = Papercraft.apply(t, foo: 'baz') { |**props| section { render_yield(**props) } }
+    html = Papercraft.html(a) { |bar:| h1 bar }
+    assert_equal "<div><section><h1>baz</h1></section></div>", html
+  end
+
+  def test_papercraft_apply_nested_render_yield
+    t = ->(foo:) { div { render_yield(bar: foo) } }
+    a = Papercraft.apply(t, foo: 'baz')
+    html = Papercraft.html(a) { |bar:| h1 bar }
+    assert_equal "<div><h1>baz</h1></div>", html
+    
+  end
 end

--- a/test/test_template.rb
+++ b/test/test_template.rb
@@ -7,79 +7,80 @@ require 'papercraft'
 class ParametersTest < Minitest::Test
   def test_empty_template
     t = -> { }
-    assert_equal '', t.render
+    assert_equal '', Papercraft.render(t)
 
     t = ->(foo) { }
-    assert_raises(ArgumentError) { t.render }
-    assert_equal '', t.render(1)
+    assert_raises(ArgumentError) { Papercraft.render(t) }
+    assert_equal '', Papercraft.render(t, 1)
   end
 
   def test_simple_template
     h = ->(foo) { h1 foo }
 
-    assert_raises(ArgumentError) { h.render }
-    assert_equal '<h1>bar</h1>', h.render('bar')
+    assert_raises(ArgumentError) { Papercraft.render(h) }
+    assert_equal '<h1>bar</h1>', Papercraft.render(h, 'bar')
   end
 
   def test_ordinal_parameters
     h = proc { |foo = 'baz'| h1 foo }
 
-    assert_equal '<h1>baz</h1>', h.render
-    assert_equal '<h1>bar</h1>', h.render('bar')
+    assert_equal '<h1>baz</h1>', Papercraft.render(h)
+    assert_equal '<h1>bar</h1>', Papercraft.render(h, 'bar')
 
     h = proc { |foo = 'default', *rest| h2 foo; h3 rest.inspect }
-    assert_equal '<h2>default</h2><h3>[]</h3>', h.render
-    assert_equal '<h2>23</h2><h3>[]</h3>', h.render(23)
-    assert_equal '<h2>42</h2><h3>[43, 44]</h3>', h.render(42, 43, 44)
+    assert_equal '<h2>default</h2><h3>[]</h3>', Papercraft.render(h)     
+    assert_equal '<h2>23</h2><h3>[]</h3>', Papercraft.render(h, 23)
+    assert_equal '<h2>42</h2><h3>[43, 44]</h3>', Papercraft.render(h, 42, 43, 44)
 
     h = ->(foo = true) { raw(foo ? 'yes' : 'no') }
-    assert_equal 'yes', h.render
-    assert_equal 'no', h.render(false)
+    assert_equal 'yes', Papercraft.render(h)
+    assert_equal 'no', Papercraft.render(h, false)
   end
 
   def test_named_parameters
     h = proc { |foo:| h1 foo }
-    assert_raises(ArgumentError) { h.render }
-    assert_raises(ArgumentError) { h.render(bar: 1) }
-    assert_equal '<h1>bar</h1>', h.render(foo: 'bar')
+    assert_raises(ArgumentError) { Papercraft.render(h) }
+    assert_raises(ArgumentError) { Papercraft.render(h, bar: 1) }
+    assert_equal '<h1>bar</h1>', Papercraft.render(h, foo: 'bar')
 
     h = proc { |foo:, bar:| h2 foo; h3 bar }
-    assert_raises(ArgumentError) { h.render }
-    assert_raises(ArgumentError) { h.render(foo: 1) }
-    assert_raises(ArgumentError) { h.render(bar: 2) }
-    assert_equal '<h2>42</h2><h3>43</h3>',
-      h.render(foo: 42, bar: 43)
+    assert_raises(ArgumentError) { Papercraft.render(h) }
+    assert_raises(ArgumentError) { Papercraft.render(h, foo: 1) }
+    assert_raises(ArgumentError) { Papercraft.render(h, bar: 2) }
+    assert_equal '<h2>42</h2><h3>43</h3>', Papercraft.render(h, foo: 42, bar: 43)
 
     h = proc { |foo: true| raw foo ? 'yes' : 'no' }
-    assert_equal 'yes', h.render
-    assert_equal 'no', h.render(foo: false)
+    assert_equal 'yes', Papercraft.render(h)
+    assert_equal 'no', Papercraft.render(h, foo: false)
   end
 
   def test_mixed_parameters
     h = proc { |foo, bar:, baz:| h1 foo; h2 bar; h3 baz }
-    assert_raises(ArgumentError) { h.render }
-    assert_raises(ArgumentError) { h.render(1) }
-    assert_raises(ArgumentError) { h.render(1, foo: 2) }
-    assert_raises(ArgumentError) { h.render(baz: 4) }
-    assert_equal '<h1>1</h1><h2>2</h2><h3>3</h3>',
-      h.render(1, bar: 2, baz: 3)
+    assert_raises(ArgumentError) { Papercraft.render(h) }
+    assert_raises(ArgumentError) { Papercraft.render(h, 1) }
+    assert_raises(ArgumentError) { Papercraft.render(h, 1, foo: 2) }
+    assert_raises(ArgumentError) { Papercraft.render(h, baz: 4) }
+    assert_equal '<h1>1</h1><h2>2</h2><h3>3</h3>', Papercraft.render(
+      h, 1, bar: 2, baz: 3
+    )
 
     h = proc { |foo, bar: 5, baz:| h1 foo; h2 bar; h3 baz }
-    assert_raises(ArgumentError) { h.render }
-    assert_raises(ArgumentError) { h.render(1) }
-    assert_equal '<h1>1</h1><h2>5</h2><h3>3</h3>',
-      h.render(1, baz: 3)
+    assert_raises(ArgumentError) { Papercraft.render(h) }
+    assert_raises(ArgumentError) { Papercraft.render(h, 1) }
+    assert_equal '<h1>1</h1><h2>5</h2><h3>3</h3>', Papercraft.render(
+      h, 1, baz: 3
+    )
   end
 end
 
 class RenderComponentTest < Minitest::Test
   def test_render_with_proc_params
     r = proc { |p| body { render p } }
-    assert_equal '<body><h1>hi</h1></body>', r.render(
-      proc { h1 'hi' }
+    assert_equal '<body><h1>hi</h1></body>', Papercraft.render(
+      r, proc { h1 'hi' }
     )
-    assert_equal '<body><foo></foo></body>', r.render(
-      proc { foo }
+    assert_equal '<body><foo></foo></body>', Papercraft.render(
+      r, proc { foo }
     )
   end
 
@@ -90,14 +91,14 @@ class RenderComponentTest < Minitest::Test
       }
     }
     assert_raises(ArgumentError) {
-      r.render(
-        proc { |baz:|
+      Papercraft.render(
+        r, proc { |baz:|
           h1 baz
         }
       )
     }
-    assert_equal '<body><h1>2</h1></body>', r.render(
-      proc { |bar:|
+    assert_equal '<body><h1>2</h1></body>', Papercraft.render(
+      r, proc { |bar:|
         h1 bar
       }
     )
@@ -112,7 +113,8 @@ class RenderComponentTest < Minitest::Test
         button 'hi'
       }
     }
-    assert_equal '<header><h1>bar</h1><button>hi</button></header>', template.render
+    assert_equal '<header><h1>bar</h1><button>hi</button></header>', 
+      Papercraft.render(template)
   end
 
   Foo = ->(name) { h1 "Hello, #{name}!" }
@@ -121,12 +123,12 @@ class RenderComponentTest < Minitest::Test
     template = -> {
       div { render Foo, 'foo' }
     }
-    assert_equal "<div><h1>Hello, foo!</h1></div>", template.render
+    assert_equal "<div><h1>Hello, foo!</h1></div>", Papercraft.render(template)
 
     template = -> {
       div { Foo('bar') }
     }
-    assert_equal "<div><h1>Hello, bar!</h1></div>", template.render
+    assert_equal "<div><h1>Hello, bar!</h1></div>", Papercraft.render(template)
   end
 
   module Blah
@@ -137,12 +139,12 @@ class RenderComponentTest < Minitest::Test
     template = -> {
       div { render Blah::Foo, 'foo' }
     }
-    assert_equal "<div><h2>Hello, foo!</h2></div>", template.render
+    assert_equal "<div><h2>Hello, foo!</h2></div>", Papercraft.render(template)
 
     template = -> {
       div { Blah::Foo('bar') }
     }
-    assert_equal "<div><h2>Hello, bar!</h2></div>", template.render
+    assert_equal "<div><h2>Hello, bar!</h2></div>", Papercraft.render(template)
   end
 
   module A
@@ -155,29 +157,29 @@ class RenderComponentTest < Minitest::Test
     template = -> {
       div { render A::B::Foo, 'foo' }
     }
-    assert_equal "<div><h3>Hello, foo!</h3></div>", template.render
+    assert_equal "<div><h3>Hello, foo!</h3></div>", Papercraft.render(template)
 
     template = -> {
       div { A::B::Foo('bar') }
     }
-    assert_equal "<div><h3>Hello, bar!</h3></div>", template.render
+    assert_equal "<div><h3>Hello, bar!</h3></div>", Papercraft.render(template)
   end
 
   def test_render_invalid_constant_component
     template = -> {
       div { Bar('foo') }
     }
-    assert_raises(NameError) { template.render }
+    assert_raises(NameError) { Papercraft.render(template) }
 
     template = -> {
       div { Blah::Bar('foo') }
     }
-    assert_raises(NameError) { template.render }
+    assert_raises(NameError) { Papercraft.render(template) }
 
     template = -> {
       div { A::B::Bar('foo') }
     }
-    assert_raises(NameError) { template.render }
+    assert_raises(NameError) { Papercraft.render(template) }
   end
 
   module ::C
@@ -188,12 +190,12 @@ class RenderComponentTest < Minitest::Test
     template = -> {
       div { render ::C::Foo, 'foo' }
     }
-    assert_equal "<div><h4>Hello, foo!</h4></div>", template.render
+    assert_equal "<div><h4>Hello, foo!</h4></div>", Papercraft.render(template)
 
     template = -> {
       div { ::C::Foo('bar') }
     }
-    assert_equal "<div><h4>Hello, bar!</h4></div>", template.render
+    assert_equal "<div><h4>Hello, bar!</h4></div>", Papercraft.render(template)
   end
 
 
@@ -202,21 +204,21 @@ end
 class RenderYieldTest < Minitest::Test
   def test_render_yield
     r = proc { body { render_yield } }
-    assert_raises(ArgumentError) { r.render(foo: 'bar') }
+    assert_raises(ArgumentError) { Papercraft.render(r, foo: 'bar') }
 
     assert_equal(
       '<body><p>foo</p><hr></body>',
-      r.render { p 'foo'; hr; }
+      Papercraft.render(r) { p 'foo'; hr; }
     )
   end
 
   def test_render_yield_with_params
     r = proc { |foo:| body { render_yield(bar: foo * 10) } }
-    assert_raises(LocalJumpError) { r.render(foo: 1) }
-    assert_raises(ArgumentError) { r.render { |bar:| p bar } }
+    assert_raises(LocalJumpError) { Papercraft.render(r, foo: 1) }
+    assert_raises(ArgumentError) { Papercraft.render(r) { |bar:| p bar } }
     assert_equal(
       '<body><p>420</p></body>',
-      r.render(foo: 42) { |bar:| p bar }
+      Papercraft.render(r, foo: 42) { |bar:| p bar }
     )
   end
 end
@@ -225,19 +227,19 @@ class RenderChildrenTest < Minitest::Test
   def test_render_children
     r = proc { body { render_children } }
 
-    assert_raises(ArgumentError) { r.render(foo: 'bar') }
-    assert_equal '<body></body>', r.render
-    assert_equal '<body><p>foo</p><hr></body>', r.render { p 'foo'; hr; }
+    assert_raises(ArgumentError) { Papercraft.render(r, foo: 'bar') }
+    assert_equal '<body></body>', Papercraft.render(r)
+    assert_equal '<body><p>foo</p><hr></body>', Papercraft.render(r) { p 'foo'; hr; }
   end
 
   def test_render_children_with_params
     r = proc { |foo:| body { render_children(bar: foo * 10) } }
 
-    assert_equal '<body></body>', r.render(foo: 1)
-    assert_raises(ArgumentError) { r.render { |bar:| p bar } }
+    assert_equal '<body></body>', Papercraft.render(r, foo: 1)
+    assert_raises(ArgumentError) { Papercraft.render(r) { |bar:| p bar } }
     assert_equal(
       '<body><p>420</p></body>',
-      r.render(foo: 42) { |bar:| p bar }
+      Papercraft.render(r, foo: 42) { |bar:| p bar }
     )
   end
 end
@@ -249,13 +251,13 @@ class BlockCallTest < Minitest::Test
         foo.()
       }
     }
-    html = a.render { h1 'hi' }
+    html = Papercraft.render(a) { h1 'hi' }
     assert_equal '<div><h1>hi</h1></div>', html
 
-    b = a.apply { p 'ho' }
-    assert_equal '<div><p>ho</p></div>', b.render
+    b = Papercraft.apply(a) { p 'ho' }
+    assert_equal '<div><p>ho</p></div>', Papercraft.render(b)
 
-    assert_raises(NoMethodError) { a.render }
+    assert_raises(NoMethodError) { Papercraft.render(a) }
   end
 
   def test_block_call_with_block
@@ -267,7 +269,7 @@ class BlockCallTest < Minitest::Test
       }
     }
     assert_raises(Papercraft::Error) {
-      a.apply { |&c|
+      Papercraft.apply(a) { |&c|
         span(&c)
       }
     }
@@ -277,7 +279,7 @@ class BlockCallTest < Minitest::Test
     a = ->(&foo) {
       div(&foo)
     }
-    html = a.render { h1 'hi' }
+    html = Papercraft.render(a) { h1 'hi' }
     assert_equal '<div><h1>hi</h1></div>', html
   end
 end
@@ -285,21 +287,21 @@ end
 class ApplyTest < Minitest::Test
   def test_apply_with_parameters
     a = proc { |foo| body { render foo } }
-    b = a.apply(proc { p 'hi' })
+    b = Papercraft.apply(a, proc { p 'hi' })
 
     assert_kind_of Proc, b
     assert b.__compiled__?
     assert_equal(
       '<body><p>hi</p></body>',
-      b.render
+      Papercraft.render(b)
     )
   end
 
   def test_apply_with_block
     a = proc { |foo| body { render_yield(foo) } }
-    b = a.apply(&->(foo) { p foo })
-    assert_equal '<body><p>hi</p></body>', b.render('hi')
-    assert_equal (a.render('foo') { |foo| p foo }), b.render('foo')
+    b = Papercraft.apply(a, &->(foo) { p foo })
+    assert_equal '<body><p>hi</p></body>', Papercraft.render(b, 'hi')
+    assert_equal (Papercraft.render(a, 'foo') { |foo| p foo }), Papercraft.render(b, 'foo')
   end
 
   def test_apply_with_parameters_and_block
@@ -309,37 +311,37 @@ class ApplyTest < Minitest::Test
         render_yield b
       }
     }
-    b = a.apply(a: 'bar', b: 'baz') { |x, **| p x }
+    b = Papercraft.apply(a, a: 'bar', b: 'baz') { |x, **| p x }
 
     assert_kind_of Proc, b
-    assert_equal '<foo>bar</foo><body><p>baz</p></body>', b.render
+    assert_equal '<foo>bar</foo><body><p>baz</p></body>', Papercraft.render(b)
   end
 
   def test_apply_with_partial_parameters
     a = proc { |foo:, bar:| p foo; p bar }
-    b = a.apply(foo: 'aaa')
+    b = Papercraft.apply(a, foo: 'aaa')
 
-    assert_raises { b.render }
+    assert_raises { Papercraft.render(b) }
 
-    assert_equal '<p>aaa</p><p>bbb</p>', b.render(bar: 'bbb')
+    assert_equal '<p>aaa</p><p>bbb</p>', Papercraft.render(b, bar: 'bbb')
   end
 
   def test_apply_with_block_with_yield
     a = proc { body { render_yield } }
-    b = a.apply { article { render_yield } }
+    b = Papercraft.apply(a) { article { render_yield } }
 
-    c = b.render { h1 'foo' }
+    c = Papercraft.render(b) { h1 'foo' }
     assert_equal '<body><article><h1>foo</h1></article></body>', c
   end
 
   def test_apply_with_block_with_yield_with_args
     a = proc { |*a, **b| body { render_yield(*a, **b) } }
-    b = a.apply(:foo, :bar, p: 42, q: 43) { |*c, **d|
+    b = Papercraft.apply(a, :foo, :bar, p: 42, q: 43) { |*c, **d|
       article { render_yield(*c, **d) }
     }
 
     buf = []
-    c = b.render(:baz, :but, x: 1, y: 2) { |*a, **b|
+    c = Papercraft.render(b, :baz, :but, x: 1, y: 2) { |*a, **b|
       buf << a << b
       h1 "foo"
     }
@@ -357,12 +359,12 @@ class ApplyTest < Minitest::Test
 
   def test_apply_with_block_render_with_block
     a = proc { |*a, **b| body { render_yield(*a, **b) } }
-    b = a.apply(:foo, :bar, p: 42, q: 43) { |*c, **d|
+    b = Papercraft.apply(a, :foo, :bar, p: 42, q: 43) { |*c, **d|
       article { render_yield(*c, **d) }
     }
 
     buf = []
-    c = b.render(:baz, :but, x: 1, y: 2) { |*a, **b|
+    c = Papercraft.render(b, :baz, :but, x: 1, y: 2) { |*a, **b|
       buf << a << b
       h1 "foo"
     }
@@ -396,7 +398,7 @@ class ConstComponentTest < Minitest::Test
       }
     }
 
-    html = page.render('Hello from composed templates', [
+    html = Papercraft.render(page, 'Hello from composed templates', [
       { id: 1, text: 'foo', checked: false },
       { id: 2, text: 'bar', checked: true }
     ])
@@ -414,7 +416,7 @@ class TagsTest < Minitest::Test
       h1 'foo'
       tag :h2, 'bar'
     }
-    html = t.render
+    html = Papercraft.render(t)
     assert_equal('<h1>foo</h1><h2>bar</h2>', html)
   end
 
@@ -425,7 +427,7 @@ class TagsTest < Minitest::Test
         span 'bar'
       }
     }
-    html = t.render
+    html = Papercraft.render(t)
     assert_equal('<h1 id="42">foo</h1><h2 id="43"><span>bar</span></h2>', html)
 
     t = -> {
@@ -434,7 +436,7 @@ class TagsTest < Minitest::Test
         span 'bar'
       }
     }
-    html = t.render
+    html = Papercraft.render(t)
     assert_equal('<h1 id-foo="43">foo</h1><h2 x-y="44"><span>bar</span></h2>', html)
   end
 
@@ -442,7 +444,7 @@ class TagsTest < Minitest::Test
     t = ->(t) {
       tag t, 'foo'
     }
-    html = t.render(:em)
+    html = Papercraft.render(t, :em)
     assert_equal('<em>foo</em>', html)
   end
 
@@ -452,7 +454,7 @@ class TagsTest < Minitest::Test
         markdown "# Foo\n\nLorem ipsum"
       }
     }
-    html = t.render
+    html = Papercraft.render(t)
     assert_equal("<div><h1 id=\"foo\">Foo</h1>\n\n<p>Lorem ipsum</p>\n</div>", html)
   end
 
@@ -462,7 +464,7 @@ class TagsTest < Minitest::Test
         markdown "# Foo\n\nLorem ipsum"
       }
     }
-    html = t.render
+    html = Papercraft.render(t)
     assert_equal("<div><h1 id=\"foo\">Foo</h1>\n\n<p>Lorem ipsum</p>\n</div>", html)
   end
 end
@@ -483,10 +485,10 @@ class ExceptionBacktraceTest < Minitest::Test
       h2 'bar'
     }
 
-    html = t.render false
+    html = Papercraft.render(t, false)
     assert_equal '<h1>foo</h1><h2>bar</h2>', html
 
-    e = capture_exception { t.render true }
+    e = capture_exception { Papercraft.render(t, true) }
     assert_kind_of RuntimeError, e
     bt = e.backtrace
     assert_equal "#{__FILE__}:#{t_line + 3}", bt[0].match(/^(.+\:\d+)/)[1]
@@ -499,10 +501,10 @@ class ExceptionBacktraceTest < Minitest::Test
       raise if x
     }
 
-    html = t.render false
+    html = Papercraft.render(t, false)
     assert_equal '<h1>foo</h1>', html
 
-    e = capture_exception { t.render true }
+    e = capture_exception { Papercraft.render(t, true) }
     assert_kind_of RuntimeError, e
     bt = e.backtrace
     assert_equal "#{__FILE__}:#{t_line + 3}", bt[0].match(/^(.+\:\d+)/)[1]
@@ -519,7 +521,7 @@ class ExceptionBacktraceTest < Minitest::Test
       render t1
     }
 
-    e = capture_exception { t2.render }
+    e = capture_exception { Papercraft.render(t2) }
     assert_kind_of RuntimeError, e
     bt = e.backtrace
     assert_equal "#{__FILE__}:#{t1_line + 3}", bt[0].match(/^(.+\:\d+)/)[1]
@@ -536,7 +538,7 @@ class ExceptionBacktraceTest < Minitest::Test
       render t1
     }
 
-    e = capture_exception { t2.render }
+    e = capture_exception { Papercraft.render(t2) }
     assert_kind_of LocalJumpError, e
     f = e.backtrace[0]
     assert_equal "#{__FILE__}:#{t1_line + 3}", f.match(/^(.+\:\d+)/)[1]
@@ -548,7 +550,7 @@ class ExceptionBacktraceTest < Minitest::Test
       p 'foo'
     }
 
-    e = capture_exception { t.render }
+    e = capture_exception { Papercraft.render(t) }
     assert_kind_of ArgumentError, e
     f = e.backtrace[0]
     assert_equal "#{__FILE__}:#{t_line + 1}", f.match(/^(.+\:\d+)/)[1]
@@ -566,13 +568,14 @@ class TemplateWrapperTest < Minitest::Test
     })
 
     assert_equal "<p>2a</p>", t.render(42)
-    assert_equal "<p>2a</p>", t.proc.render(42)
+    assert_equal "<p>2a</p>", Papercraft.render(t, 42)
+    assert_equal "<p>2a</p>", Papercraft.render(t.proc, 42)
 
     t2 = t.apply(43)
 
     assert_kind_of Papercraft::Template, t2
-    assert_equal "<p>2b</p>", t2.render
-    assert_equal "<p>2b</p>", t2.proc.render
+    assert_equal "<p>2b</p>", Papercraft.render(t2)
+    assert_equal "<p>2b</p>", Papercraft.render(t2.proc)
   end
 
   def test_wrapper_xml
@@ -604,7 +607,7 @@ class ExtensionTest < Minitest::Test
     t = -> {
       youtube_player('foo')
     }
-    assert_equal '<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/foo"></iframe>', t.render
+    assert_equal '<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/foo"></iframe>', Papercraft.render(t)
   end
 
   def test_extension_with_block
@@ -615,14 +618,14 @@ class ExtensionTest < Minitest::Test
         p (item * 10)
       }
     }
-    assert_equal '<ul><li><p>10</p></li><li><p>20</p></li><li><p>30</p></li></ul>', t.render
+    assert_equal '<ul><li><p>10</p></li><li><p>20</p></li><li><p>30</p></li></ul>', Papercraft.render(t)
 
     t = -> {
       ulist([1, 2, 3]) {
         p (it * 10)
       }
     }
-    assert_raises(Papercraft::Error) { t.render }
+    assert_raises(Papercraft::Error) { Papercraft.render(t) }
   end
 end
 
@@ -634,21 +637,21 @@ class RenderCacheTest < Minitest::Test
       p args.join
     }
 
-    assert_equal '<p>foo</p>', t.render_cache(:foo, :foo)
+    assert_equal '<p>foo</p>', Papercraft.render_cache(t, :foo, :foo)
     assert_equal 1, counter
-    assert_equal '<p>foo</p>', t.render_cache(:foo, :foo)
+    assert_equal '<p>foo</p>', Papercraft.render_cache(t, :foo, :foo)
     assert_equal 1, counter
-    assert_equal '<p>foo</p>', t.render_cache(:foo, :bar)
+    assert_equal '<p>foo</p>', Papercraft.render_cache(t, :foo, :bar)
     assert_equal 1, counter
 
-    assert_equal '<p>bar</p>', t.render_cache(:bar, :bar)
+    assert_equal '<p>bar</p>', Papercraft.render_cache(t, :bar, :bar)
     assert_equal 2, counter
-    assert_equal '<p>bar</p>', t.render_cache(:bar, :bar)
+    assert_equal '<p>bar</p>', Papercraft.render_cache(t, :bar, :bar)
     assert_equal 2, counter
 
-    assert_equal '<p>foobar</p>', t.render_cache(:baz, :foo, :bar)
+    assert_equal '<p>foobar</p>', Papercraft.render_cache(t, :baz, :foo, :bar)
     assert_equal 3, counter
-    assert_equal '<p>foobar</p>', t.render_cache(:baz, :foo, :bar)
+    assert_equal '<p>foobar</p>', Papercraft.render_cache(t, :baz, :foo, :bar)
     assert_equal 3, counter
   end
 end
@@ -656,7 +659,7 @@ end
 class EvaldProcTest < Minitest::Test
   def test_eval_proc_error
     t = eval('-> { hr }')
-    assert_raises(Papercraft::Error) { t.render }
+    assert_raises(Papercraft::Error) { Papercraft.render(t) }
   end
 end
 
@@ -666,27 +669,27 @@ class StringEscapingTest < Minitest::Test
     t = -> {
       raw 'abc "def" ghi'
     }
-    assert_equal 'abc "def" ghi', t.render
+    assert_equal 'abc "def" ghi', Papercraft.render(t)
 
     t = -> {
       raw s
     }
-    assert_equal 'abc "def" ghi', t.render
+    assert_equal 'abc "def" ghi', Papercraft.render(t)
 
     t = -> {
       text 'abc "def" ghi'
     }
-    assert_equal 'abc &quot;def&quot; ghi', t.render
+    assert_equal 'abc &quot;def&quot; ghi', Papercraft.render(t)
 
     t = -> {
       p 'abc "def" ghi'
     }
-    assert_equal '<p>abc &quot;def&quot; ghi</p>', t.render
+    assert_equal '<p>abc &quot;def&quot; ghi</p>', Papercraft.render(t)
 
     t = -> {
       p s
     }
-    assert_equal '<p>abc &quot;def&quot; ghi</p>', t.render
+    assert_equal '<p>abc &quot;def&quot; ghi</p>', Papercraft.render(t)
   end
 end
 
@@ -701,7 +704,7 @@ class AttributeInjectionTest < Minitest::Test
       { 'data-papercraft-fn' => fn, 'data-papercraft-loc' => "foo://#{fn}:#{line}:#{col}" }
     }
 
-    html = t.render
+    html = Papercraft.render(t)
 
     assert_equal "<p data-papercraft-fn=\"#{__FILE__}\" data-papercraft-loc=\"foo://#{__FILE__}:#{line + 2}:7\">foo</p>", html
   ensure
@@ -718,7 +721,7 @@ class AttributeInjectionTest < Minitest::Test
       { 'data-papercraft-fn' => fn, 'data-papercraft-loc' => "foo://#{fn}:#{line}:#{col}" }
     }
 
-    html = t.render
+    html = Papercraft.render(t)
 
     assert_equal "<p data-papercraft-fn=\"#{__FILE__}\" data-papercraft-loc=\"foo://#{__FILE__}:#{line + 2}:7\" class=\"bar\" baz>foo</p>", html
   ensure
@@ -736,7 +739,7 @@ class AttributeInjectionTest < Minitest::Test
       { 'data-papercraft-fn' => fn, 'data-papercraft-loc' => "foo://#{fn}:#{line}:#{col}" }
     }
 
-    html = t.render
+    html = Papercraft.render(t)
     assert_equal "<p data-papercraft-fn=\"#{__FILE__}\" data-papercraft-loc=\"foo://#{__FILE__}:#{line + 3}:7\" class=\"bar\" baz>foo</p>", html
   ensure
     Papercraft::Compiler.html_debug_attribute_injector = nil
@@ -756,7 +759,7 @@ class AttributeInjectionTest < Minitest::Test
       { 'data-papercraft-level' => level, 'data-papercraft-fn' => fn, 'data-papercraft-loc' => "foo://#{fn}:#{line}:#{col}" }
     }
 
-    html = t.render
+    html = Papercraft.render(t)
 
     expected = "<div data-papercraft-level=\"1\" data-papercraft-fn=\"#{__FILE__}\" data-papercraft-loc=\"foo://#{__FILE__}:#{line + 2}:7\">" +
                "<h1 data-papercraft-level=\"2\" data-papercraft-fn=\"#{__FILE__}\" data-papercraft-loc=\"foo://#{__FILE__}:#{line + 3}:9\">" +
@@ -773,7 +776,7 @@ class RawIOnnerTextTest < Minitest::Test
       script 'let a = 1 & 2; let b = "abc";'
     }
 
-    assert_equal '<script>let a = 1 & 2; let b = "abc";</script>', t.render
+    assert_equal '<script>let a = 1 & 2; let b = "abc";</script>', Papercraft.render(t)
   end
 
   def test_script_tag_module_with_content
@@ -781,7 +784,7 @@ class RawIOnnerTextTest < Minitest::Test
       script 'let a = 1 & 2; let b = "abc";', type: 'module'
     }
 
-    assert_equal '<script type="module">let a = 1 & 2; let b = "abc";</script>', t.render
+    assert_equal '<script type="module">let a = 1 & 2; let b = "abc";</script>', Papercraft.render(t)
   end
 
   def test_style_tag_with_content
@@ -789,7 +792,7 @@ class RawIOnnerTextTest < Minitest::Test
       style 'a&b { color: black }'
     }
 
-    assert_equal '<style>a&b { color: black }</style>', t.render
+    assert_equal '<style>a&b { color: black }</style>', Papercraft.render(t)
   end
 
   def test_script_tag_module_with_content
@@ -797,7 +800,7 @@ class RawIOnnerTextTest < Minitest::Test
       style 'a&b { color: black }', media: '(width < 500px)'
     }
 
-    assert_equal '<style media="(width < 500px)">a&b { color: black }</style>', t.render
+    assert_equal '<style media="(width < 500px)">a&b { color: black }</style>', Papercraft.render(t)
   end
 end
 
@@ -810,17 +813,17 @@ class MethodChainingTest < Minitest::Test
     t = -> {
       foo
     }
-    assert_equal '<foo></foo>', t.render
+    assert_equal '<foo></foo>', Papercraft.render(t)
 
     t = -> {
       foo[0]
     }
-    assert_equal '<foo></foo>', t.render
+    assert_equal '<foo></foo>', Papercraft.render(t)
 
     buf = []
     t = -> {
       buf.size
     }
-    assert_equal '', t.render
+    assert_equal '', Papercraft.render(t)
   end
 end

--- a/test/test_template.rb
+++ b/test/test_template.rb
@@ -290,7 +290,7 @@ class ApplyTest < Minitest::Test
     b = Papercraft.apply(a, proc { p 'hi' })
 
     assert_kind_of Proc, b
-    assert b.__compiled__?
+    assert b.__papercraft_compiled?
     assert_equal(
       '<body><p>hi</p></body>',
       Papercraft.render(b)

--- a/test/test_template.rb
+++ b/test/test_template.rb
@@ -568,6 +568,7 @@ class TemplateWrapperTest < Minitest::Test
     })
 
     assert_equal "<p>2a</p>", t.render(42)
+    assert_equal "<p>2a</p>", t.call(42)
     assert_equal "<p>2a</p>", Papercraft.render(t, 42)
     assert_equal "<p>2a</p>", Papercraft.render(t.proc, 42)
 
@@ -582,6 +583,14 @@ class TemplateWrapperTest < Minitest::Test
     t = Papercraft::Template.new(-> { link 'foo' }, mode: :xml)
     assert_equal "<link>foo</link>", t.render
     assert_equal :xml, t.mode
+  end
+
+  def test_wrapper_with_block
+    t = Papercraft::Template.new { |x|
+      p x.to_s(16)
+    }
+    assert_equal "<p>2a</p>", t.render(42)
+    assert_equal "<p>2a</p>", t.call(42)
   end
 end
 

--- a/test/test_template.rb
+++ b/test/test_template.rb
@@ -7,67 +7,67 @@ require 'papercraft'
 class ParametersTest < Minitest::Test
   def test_empty_template
     t = -> { }
-    assert_equal '', Papercraft.render(t)
+    assert_equal '', Papercraft.html(t)
 
     t = ->(foo) { }
-    assert_raises(ArgumentError) { Papercraft.render(t) }
-    assert_equal '', Papercraft.render(t, 1)
+    assert_raises(ArgumentError) { Papercraft.html(t) }
+    assert_equal '', Papercraft.html(t, 1)
   end
 
   def test_simple_template
     h = ->(foo) { h1 foo }
 
-    assert_raises(ArgumentError) { Papercraft.render(h) }
-    assert_equal '<h1>bar</h1>', Papercraft.render(h, 'bar')
+    assert_raises(ArgumentError) { Papercraft.html(h) }
+    assert_equal '<h1>bar</h1>', Papercraft.html(h, 'bar')
   end
 
   def test_ordinal_parameters
     h = proc { |foo = 'baz'| h1 foo }
 
-    assert_equal '<h1>baz</h1>', Papercraft.render(h)
-    assert_equal '<h1>bar</h1>', Papercraft.render(h, 'bar')
+    assert_equal '<h1>baz</h1>', Papercraft.html(h)
+    assert_equal '<h1>bar</h1>', Papercraft.html(h, 'bar')
 
     h = proc { |foo = 'default', *rest| h2 foo; h3 rest.inspect }
-    assert_equal '<h2>default</h2><h3>[]</h3>', Papercraft.render(h)     
-    assert_equal '<h2>23</h2><h3>[]</h3>', Papercraft.render(h, 23)
-    assert_equal '<h2>42</h2><h3>[43, 44]</h3>', Papercraft.render(h, 42, 43, 44)
+    assert_equal '<h2>default</h2><h3>[]</h3>', Papercraft.html(h)     
+    assert_equal '<h2>23</h2><h3>[]</h3>', Papercraft.html(h, 23)
+    assert_equal '<h2>42</h2><h3>[43, 44]</h3>', Papercraft.html(h, 42, 43, 44)
 
     h = ->(foo = true) { raw(foo ? 'yes' : 'no') }
-    assert_equal 'yes', Papercraft.render(h)
-    assert_equal 'no', Papercraft.render(h, false)
+    assert_equal 'yes', Papercraft.html(h)
+    assert_equal 'no', Papercraft.html(h, false)
   end
 
   def test_named_parameters
     h = proc { |foo:| h1 foo }
-    assert_raises(ArgumentError) { Papercraft.render(h) }
-    assert_raises(ArgumentError) { Papercraft.render(h, bar: 1) }
-    assert_equal '<h1>bar</h1>', Papercraft.render(h, foo: 'bar')
+    assert_raises(ArgumentError) { Papercraft.html(h) }
+    assert_raises(ArgumentError) { Papercraft.html(h, bar: 1) }
+    assert_equal '<h1>bar</h1>', Papercraft.html(h, foo: 'bar')
 
     h = proc { |foo:, bar:| h2 foo; h3 bar }
-    assert_raises(ArgumentError) { Papercraft.render(h) }
-    assert_raises(ArgumentError) { Papercraft.render(h, foo: 1) }
-    assert_raises(ArgumentError) { Papercraft.render(h, bar: 2) }
-    assert_equal '<h2>42</h2><h3>43</h3>', Papercraft.render(h, foo: 42, bar: 43)
+    assert_raises(ArgumentError) { Papercraft.html(h) }
+    assert_raises(ArgumentError) { Papercraft.html(h, foo: 1) }
+    assert_raises(ArgumentError) { Papercraft.html(h, bar: 2) }
+    assert_equal '<h2>42</h2><h3>43</h3>', Papercraft.html(h, foo: 42, bar: 43)
 
     h = proc { |foo: true| raw foo ? 'yes' : 'no' }
-    assert_equal 'yes', Papercraft.render(h)
-    assert_equal 'no', Papercraft.render(h, foo: false)
+    assert_equal 'yes', Papercraft.html(h)
+    assert_equal 'no', Papercraft.html(h, foo: false)
   end
 
   def test_mixed_parameters
     h = proc { |foo, bar:, baz:| h1 foo; h2 bar; h3 baz }
-    assert_raises(ArgumentError) { Papercraft.render(h) }
-    assert_raises(ArgumentError) { Papercraft.render(h, 1) }
-    assert_raises(ArgumentError) { Papercraft.render(h, 1, foo: 2) }
-    assert_raises(ArgumentError) { Papercraft.render(h, baz: 4) }
-    assert_equal '<h1>1</h1><h2>2</h2><h3>3</h3>', Papercraft.render(
+    assert_raises(ArgumentError) { Papercraft.html(h) }
+    assert_raises(ArgumentError) { Papercraft.html(h, 1) }
+    assert_raises(ArgumentError) { Papercraft.html(h, 1, foo: 2) }
+    assert_raises(ArgumentError) { Papercraft.html(h, baz: 4) }
+    assert_equal '<h1>1</h1><h2>2</h2><h3>3</h3>', Papercraft.html(
       h, 1, bar: 2, baz: 3
     )
 
     h = proc { |foo, bar: 5, baz:| h1 foo; h2 bar; h3 baz }
-    assert_raises(ArgumentError) { Papercraft.render(h) }
-    assert_raises(ArgumentError) { Papercraft.render(h, 1) }
-    assert_equal '<h1>1</h1><h2>5</h2><h3>3</h3>', Papercraft.render(
+    assert_raises(ArgumentError) { Papercraft.html(h) }
+    assert_raises(ArgumentError) { Papercraft.html(h, 1) }
+    assert_equal '<h1>1</h1><h2>5</h2><h3>3</h3>', Papercraft.html(
       h, 1, baz: 3
     )
   end
@@ -76,10 +76,10 @@ end
 class RenderComponentTest < Minitest::Test
   def test_render_with_proc_params
     r = proc { |p| body { render p } }
-    assert_equal '<body><h1>hi</h1></body>', Papercraft.render(
+    assert_equal '<body><h1>hi</h1></body>', Papercraft.html(
       r, proc { h1 'hi' }
     )
-    assert_equal '<body><foo></foo></body>', Papercraft.render(
+    assert_equal '<body><foo></foo></body>', Papercraft.html(
       r, proc { foo }
     )
   end
@@ -91,13 +91,13 @@ class RenderComponentTest < Minitest::Test
       }
     }
     assert_raises(ArgumentError) {
-      Papercraft.render(
+      Papercraft.html(
         r, proc { |baz:|
           h1 baz
         }
       )
     }
-    assert_equal '<body><h1>2</h1></body>', Papercraft.render(
+    assert_equal '<body><h1>2</h1></body>', Papercraft.html(
       r, proc { |bar:|
         h1 bar
       }
@@ -114,7 +114,7 @@ class RenderComponentTest < Minitest::Test
       }
     }
     assert_equal '<header><h1>bar</h1><button>hi</button></header>', 
-      Papercraft.render(template)
+      Papercraft.html(template)
   end
 
   Foo = ->(name) { h1 "Hello, #{name}!" }
@@ -123,12 +123,12 @@ class RenderComponentTest < Minitest::Test
     template = -> {
       div { render Foo, 'foo' }
     }
-    assert_equal "<div><h1>Hello, foo!</h1></div>", Papercraft.render(template)
+    assert_equal "<div><h1>Hello, foo!</h1></div>", Papercraft.html(template)
 
     template = -> {
       div { Foo('bar') }
     }
-    assert_equal "<div><h1>Hello, bar!</h1></div>", Papercraft.render(template)
+    assert_equal "<div><h1>Hello, bar!</h1></div>", Papercraft.html(template)
   end
 
   module Blah
@@ -139,12 +139,12 @@ class RenderComponentTest < Minitest::Test
     template = -> {
       div { render Blah::Foo, 'foo' }
     }
-    assert_equal "<div><h2>Hello, foo!</h2></div>", Papercraft.render(template)
+    assert_equal "<div><h2>Hello, foo!</h2></div>", Papercraft.html(template)
 
     template = -> {
       div { Blah::Foo('bar') }
     }
-    assert_equal "<div><h2>Hello, bar!</h2></div>", Papercraft.render(template)
+    assert_equal "<div><h2>Hello, bar!</h2></div>", Papercraft.html(template)
   end
 
   module A
@@ -157,29 +157,29 @@ class RenderComponentTest < Minitest::Test
     template = -> {
       div { render A::B::Foo, 'foo' }
     }
-    assert_equal "<div><h3>Hello, foo!</h3></div>", Papercraft.render(template)
+    assert_equal "<div><h3>Hello, foo!</h3></div>", Papercraft.html(template)
 
     template = -> {
       div { A::B::Foo('bar') }
     }
-    assert_equal "<div><h3>Hello, bar!</h3></div>", Papercraft.render(template)
+    assert_equal "<div><h3>Hello, bar!</h3></div>", Papercraft.html(template)
   end
 
   def test_render_invalid_constant_component
     template = -> {
       div { Bar('foo') }
     }
-    assert_raises(NameError) { Papercraft.render(template) }
+    assert_raises(NameError) { Papercraft.html(template) }
 
     template = -> {
       div { Blah::Bar('foo') }
     }
-    assert_raises(NameError) { Papercraft.render(template) }
+    assert_raises(NameError) { Papercraft.html(template) }
 
     template = -> {
       div { A::B::Bar('foo') }
     }
-    assert_raises(NameError) { Papercraft.render(template) }
+    assert_raises(NameError) { Papercraft.html(template) }
   end
 
   module ::C
@@ -190,12 +190,12 @@ class RenderComponentTest < Minitest::Test
     template = -> {
       div { render ::C::Foo, 'foo' }
     }
-    assert_equal "<div><h4>Hello, foo!</h4></div>", Papercraft.render(template)
+    assert_equal "<div><h4>Hello, foo!</h4></div>", Papercraft.html(template)
 
     template = -> {
       div { ::C::Foo('bar') }
     }
-    assert_equal "<div><h4>Hello, bar!</h4></div>", Papercraft.render(template)
+    assert_equal "<div><h4>Hello, bar!</h4></div>", Papercraft.html(template)
   end
 
 
@@ -204,21 +204,21 @@ end
 class RenderYieldTest < Minitest::Test
   def test_render_yield
     r = proc { body { render_yield } }
-    assert_raises(ArgumentError) { Papercraft.render(r, foo: 'bar') }
+    assert_raises(ArgumentError) { Papercraft.html(r, foo: 'bar') }
 
     assert_equal(
       '<body><p>foo</p><hr></body>',
-      Papercraft.render(r) { p 'foo'; hr; }
+      Papercraft.html(r) { p 'foo'; hr; }
     )
   end
 
   def test_render_yield_with_params
     r = proc { |foo:| body { render_yield(bar: foo * 10) } }
-    assert_raises(LocalJumpError) { Papercraft.render(r, foo: 1) }
-    assert_raises(ArgumentError) { Papercraft.render(r) { |bar:| p bar } }
+    assert_raises(LocalJumpError) { Papercraft.html(r, foo: 1) }
+    assert_raises(ArgumentError) { Papercraft.html(r) { |bar:| p bar } }
     assert_equal(
       '<body><p>420</p></body>',
-      Papercraft.render(r, foo: 42) { |bar:| p bar }
+      Papercraft.html(r, foo: 42) { |bar:| p bar }
     )
   end
 end
@@ -227,19 +227,19 @@ class RenderChildrenTest < Minitest::Test
   def test_render_children
     r = proc { body { render_children } }
 
-    assert_raises(ArgumentError) { Papercraft.render(r, foo: 'bar') }
-    assert_equal '<body></body>', Papercraft.render(r)
-    assert_equal '<body><p>foo</p><hr></body>', Papercraft.render(r) { p 'foo'; hr; }
+    assert_raises(ArgumentError) { Papercraft.html(r, foo: 'bar') }
+    assert_equal '<body></body>', Papercraft.html(r)
+    assert_equal '<body><p>foo</p><hr></body>', Papercraft.html(r) { p 'foo'; hr; }
   end
 
   def test_render_children_with_params
     r = proc { |foo:| body { render_children(bar: foo * 10) } }
 
-    assert_equal '<body></body>', Papercraft.render(r, foo: 1)
-    assert_raises(ArgumentError) { Papercraft.render(r) { |bar:| p bar } }
+    assert_equal '<body></body>', Papercraft.html(r, foo: 1)
+    assert_raises(ArgumentError) { Papercraft.html(r) { |bar:| p bar } }
     assert_equal(
       '<body><p>420</p></body>',
-      Papercraft.render(r, foo: 42) { |bar:| p bar }
+      Papercraft.html(r, foo: 42) { |bar:| p bar }
     )
   end
 end
@@ -251,13 +251,13 @@ class BlockCallTest < Minitest::Test
         foo.()
       }
     }
-    html = Papercraft.render(a) { h1 'hi' }
+    html = Papercraft.html(a) { h1 'hi' }
     assert_equal '<div><h1>hi</h1></div>', html
 
     b = Papercraft.apply(a) { p 'ho' }
-    assert_equal '<div><p>ho</p></div>', Papercraft.render(b)
+    assert_equal '<div><p>ho</p></div>', Papercraft.html(b)
 
-    assert_raises(NoMethodError) { Papercraft.render(a) }
+    assert_raises(NoMethodError) { Papercraft.html(a) }
   end
 
   def test_block_call_with_block
@@ -279,7 +279,7 @@ class BlockCallTest < Minitest::Test
     a = ->(&foo) {
       div(&foo)
     }
-    html = Papercraft.render(a) { h1 'hi' }
+    html = Papercraft.html(a) { h1 'hi' }
     assert_equal '<div><h1>hi</h1></div>', html
   end
 end
@@ -293,15 +293,15 @@ class ApplyTest < Minitest::Test
     assert b.__papercraft_compiled?
     assert_equal(
       '<body><p>hi</p></body>',
-      Papercraft.render(b)
+      Papercraft.html(b)
     )
   end
 
   def test_apply_with_block
     a = proc { |foo| body { render_yield(foo) } }
     b = Papercraft.apply(a, &->(foo) { p foo })
-    assert_equal '<body><p>hi</p></body>', Papercraft.render(b, 'hi')
-    assert_equal (Papercraft.render(a, 'foo') { |foo| p foo }), Papercraft.render(b, 'foo')
+    assert_equal '<body><p>hi</p></body>', Papercraft.html(b, 'hi')
+    assert_equal (Papercraft.html(a, 'foo') { |foo| p foo }), Papercraft.html(b, 'foo')
   end
 
   def test_apply_with_parameters_and_block
@@ -314,23 +314,23 @@ class ApplyTest < Minitest::Test
     b = Papercraft.apply(a, a: 'bar', b: 'baz') { |x, **| p x }
 
     assert_kind_of Proc, b
-    assert_equal '<foo>bar</foo><body><p>baz</p></body>', Papercraft.render(b)
+    assert_equal '<foo>bar</foo><body><p>baz</p></body>', Papercraft.html(b)
   end
 
   def test_apply_with_partial_parameters
     a = proc { |foo:, bar:| p foo; p bar }
     b = Papercraft.apply(a, foo: 'aaa')
 
-    assert_raises { Papercraft.render(b) }
+    assert_raises { Papercraft.html(b) }
 
-    assert_equal '<p>aaa</p><p>bbb</p>', Papercraft.render(b, bar: 'bbb')
+    assert_equal '<p>aaa</p><p>bbb</p>', Papercraft.html(b, bar: 'bbb')
   end
 
   def test_apply_with_block_with_yield
     a = proc { body { render_yield } }
     b = Papercraft.apply(a) { article { render_yield } }
 
-    c = Papercraft.render(b) { h1 'foo' }
+    c = Papercraft.html(b) { h1 'foo' }
     assert_equal '<body><article><h1>foo</h1></article></body>', c
   end
 
@@ -341,7 +341,7 @@ class ApplyTest < Minitest::Test
     }
 
     buf = []
-    c = Papercraft.render(b, :baz, :but, x: 1, y: 2) { |*a, **b|
+    c = Papercraft.html(b, :baz, :but, x: 1, y: 2) { |*a, **b|
       buf << a << b
       h1 "foo"
     }
@@ -364,7 +364,7 @@ class ApplyTest < Minitest::Test
     }
 
     buf = []
-    c = Papercraft.render(b, :baz, :but, x: 1, y: 2) { |*a, **b|
+    c = Papercraft.html(b, :baz, :but, x: 1, y: 2) { |*a, **b|
       buf << a << b
       h1 "foo"
     }
@@ -398,7 +398,7 @@ class ConstComponentTest < Minitest::Test
       }
     }
 
-    html = Papercraft.render(page, 'Hello from composed templates', [
+    html = Papercraft.html(page, 'Hello from composed templates', [
       { id: 1, text: 'foo', checked: false },
       { id: 2, text: 'bar', checked: true }
     ])
@@ -416,7 +416,7 @@ class TagsTest < Minitest::Test
       h1 'foo'
       tag :h2, 'bar'
     }
-    html = Papercraft.render(t)
+    html = Papercraft.html(t)
     assert_equal('<h1>foo</h1><h2>bar</h2>', html)
   end
 
@@ -427,7 +427,7 @@ class TagsTest < Minitest::Test
         span 'bar'
       }
     }
-    html = Papercraft.render(t)
+    html = Papercraft.html(t)
     assert_equal('<h1 id="42">foo</h1><h2 id="43"><span>bar</span></h2>', html)
 
     t = -> {
@@ -436,7 +436,7 @@ class TagsTest < Minitest::Test
         span 'bar'
       }
     }
-    html = Papercraft.render(t)
+    html = Papercraft.html(t)
     assert_equal('<h1 id-foo="43">foo</h1><h2 x-y="44"><span>bar</span></h2>', html)
   end
 
@@ -444,7 +444,7 @@ class TagsTest < Minitest::Test
     t = ->(t) {
       tag t, 'foo'
     }
-    html = Papercraft.render(t, :em)
+    html = Papercraft.html(t, :em)
     assert_equal('<em>foo</em>', html)
   end
 
@@ -454,7 +454,7 @@ class TagsTest < Minitest::Test
         markdown "# Foo\n\nLorem ipsum"
       }
     }
-    html = Papercraft.render(t)
+    html = Papercraft.html(t)
     assert_equal("<div><h1 id=\"foo\">Foo</h1>\n\n<p>Lorem ipsum</p>\n</div>", html)
   end
 
@@ -464,7 +464,7 @@ class TagsTest < Minitest::Test
         markdown "# Foo\n\nLorem ipsum"
       }
     }
-    html = Papercraft.render(t)
+    html = Papercraft.html(t)
     assert_equal("<div><h1 id=\"foo\">Foo</h1>\n\n<p>Lorem ipsum</p>\n</div>", html)
   end
 end
@@ -485,10 +485,10 @@ class ExceptionBacktraceTest < Minitest::Test
       h2 'bar'
     }
 
-    html = Papercraft.render(t, false)
+    html = Papercraft.html(t, false)
     assert_equal '<h1>foo</h1><h2>bar</h2>', html
 
-    e = capture_exception { Papercraft.render(t, true) }
+    e = capture_exception { Papercraft.html(t, true) }
     assert_kind_of RuntimeError, e
     bt = e.backtrace
     assert_equal "#{__FILE__}:#{t_line + 3}", bt[0].match(/^(.+\:\d+)/)[1]
@@ -501,10 +501,10 @@ class ExceptionBacktraceTest < Minitest::Test
       raise if x
     }
 
-    html = Papercraft.render(t, false)
+    html = Papercraft.html(t, false)
     assert_equal '<h1>foo</h1>', html
 
-    e = capture_exception { Papercraft.render(t, true) }
+    e = capture_exception { Papercraft.html(t, true) }
     assert_kind_of RuntimeError, e
     bt = e.backtrace
     assert_equal "#{__FILE__}:#{t_line + 3}", bt[0].match(/^(.+\:\d+)/)[1]
@@ -521,7 +521,7 @@ class ExceptionBacktraceTest < Minitest::Test
       render t1
     }
 
-    e = capture_exception { Papercraft.render(t2) }
+    e = capture_exception { Papercraft.html(t2) }
     assert_kind_of RuntimeError, e
     bt = e.backtrace
     assert_equal "#{__FILE__}:#{t1_line + 3}", bt[0].match(/^(.+\:\d+)/)[1]
@@ -538,7 +538,7 @@ class ExceptionBacktraceTest < Minitest::Test
       render t1
     }
 
-    e = capture_exception { Papercraft.render(t2) }
+    e = capture_exception { Papercraft.html(t2) }
     assert_kind_of LocalJumpError, e
     f = e.backtrace[0]
     assert_equal "#{__FILE__}:#{t1_line + 3}", f.match(/^(.+\:\d+)/)[1]
@@ -550,7 +550,7 @@ class ExceptionBacktraceTest < Minitest::Test
       p 'foo'
     }
 
-    e = capture_exception { Papercraft.render(t) }
+    e = capture_exception { Papercraft.html(t) }
     assert_kind_of ArgumentError, e
     f = e.backtrace[0]
     assert_equal "#{__FILE__}:#{t_line + 1}", f.match(/^(.+\:\d+)/)[1]
@@ -569,14 +569,14 @@ class TemplateWrapperTest < Minitest::Test
 
     assert_equal "<p>2a</p>", t.render(42)
     assert_equal "<p>2a</p>", t.call(42)
-    assert_equal "<p>2a</p>", Papercraft.render(t, 42)
-    assert_equal "<p>2a</p>", Papercraft.render(t.proc, 42)
+    assert_equal "<p>2a</p>", Papercraft.html(t, 42)
+    assert_equal "<p>2a</p>", Papercraft.html(t.proc, 42)
 
     t2 = t.apply(43)
 
     assert_kind_of Papercraft::Template, t2
-    assert_equal "<p>2b</p>", Papercraft.render(t2)
-    assert_equal "<p>2b</p>", Papercraft.render(t2.proc)
+    assert_equal "<p>2b</p>", Papercraft.html(t2)
+    assert_equal "<p>2b</p>", Papercraft.html(t2.proc)
   end
 
   def test_wrapper_xml
@@ -616,7 +616,7 @@ class ExtensionTest < Minitest::Test
     t = -> {
       youtube_player('foo')
     }
-    assert_equal '<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/foo"></iframe>', Papercraft.render(t)
+    assert_equal '<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/foo"></iframe>', Papercraft.html(t)
   end
 
   def test_extension_with_block
@@ -627,14 +627,14 @@ class ExtensionTest < Minitest::Test
         p (item * 10)
       }
     }
-    assert_equal '<ul><li><p>10</p></li><li><p>20</p></li><li><p>30</p></li></ul>', Papercraft.render(t)
+    assert_equal '<ul><li><p>10</p></li><li><p>20</p></li><li><p>30</p></li></ul>', Papercraft.html(t)
 
     t = -> {
       ulist([1, 2, 3]) {
         p (it * 10)
       }
     }
-    assert_raises(Papercraft::Error) { Papercraft.render(t) }
+    assert_raises(Papercraft::Error) { Papercraft.html(t) }
   end
 end
 
@@ -646,21 +646,21 @@ class RenderCacheTest < Minitest::Test
       p args.join
     }
 
-    assert_equal '<p>foo</p>', Papercraft.render_cache(t, :foo, :foo)
+    assert_equal '<p>foo</p>', Papercraft.cache_html(t, :foo, :foo)
     assert_equal 1, counter
-    assert_equal '<p>foo</p>', Papercraft.render_cache(t, :foo, :foo)
+    assert_equal '<p>foo</p>', Papercraft.cache_html(t, :foo, :foo)
     assert_equal 1, counter
-    assert_equal '<p>foo</p>', Papercraft.render_cache(t, :foo, :bar)
+    assert_equal '<p>foo</p>', Papercraft.cache_html(t, :foo, :bar)
     assert_equal 1, counter
 
-    assert_equal '<p>bar</p>', Papercraft.render_cache(t, :bar, :bar)
+    assert_equal '<p>bar</p>', Papercraft.cache_html(t, :bar, :bar)
     assert_equal 2, counter
-    assert_equal '<p>bar</p>', Papercraft.render_cache(t, :bar, :bar)
+    assert_equal '<p>bar</p>', Papercraft.cache_html(t, :bar, :bar)
     assert_equal 2, counter
 
-    assert_equal '<p>foobar</p>', Papercraft.render_cache(t, :baz, :foo, :bar)
+    assert_equal '<p>foobar</p>', Papercraft.cache_html(t, :baz, :foo, :bar)
     assert_equal 3, counter
-    assert_equal '<p>foobar</p>', Papercraft.render_cache(t, :baz, :foo, :bar)
+    assert_equal '<p>foobar</p>', Papercraft.cache_html(t, :baz, :foo, :bar)
     assert_equal 3, counter
   end
 end
@@ -668,7 +668,7 @@ end
 class EvaldProcTest < Minitest::Test
   def test_eval_proc_error
     t = eval('-> { hr }')
-    assert_raises(Papercraft::Error) { Papercraft.render(t) }
+    assert_raises(Papercraft::Error) { Papercraft.html(t) }
   end
 end
 
@@ -678,27 +678,27 @@ class StringEscapingTest < Minitest::Test
     t = -> {
       raw 'abc "def" ghi'
     }
-    assert_equal 'abc "def" ghi', Papercraft.render(t)
+    assert_equal 'abc "def" ghi', Papercraft.html(t)
 
     t = -> {
       raw s
     }
-    assert_equal 'abc "def" ghi', Papercraft.render(t)
+    assert_equal 'abc "def" ghi', Papercraft.html(t)
 
     t = -> {
       text 'abc "def" ghi'
     }
-    assert_equal 'abc &quot;def&quot; ghi', Papercraft.render(t)
+    assert_equal 'abc &quot;def&quot; ghi', Papercraft.html(t)
 
     t = -> {
       p 'abc "def" ghi'
     }
-    assert_equal '<p>abc &quot;def&quot; ghi</p>', Papercraft.render(t)
+    assert_equal '<p>abc &quot;def&quot; ghi</p>', Papercraft.html(t)
 
     t = -> {
       p s
     }
-    assert_equal '<p>abc &quot;def&quot; ghi</p>', Papercraft.render(t)
+    assert_equal '<p>abc &quot;def&quot; ghi</p>', Papercraft.html(t)
   end
 end
 
@@ -713,7 +713,7 @@ class AttributeInjectionTest < Minitest::Test
       { 'data-papercraft-fn' => fn, 'data-papercraft-loc' => "foo://#{fn}:#{line}:#{col}" }
     }
 
-    html = Papercraft.render(t)
+    html = Papercraft.html(t)
 
     assert_equal "<p data-papercraft-fn=\"#{__FILE__}\" data-papercraft-loc=\"foo://#{__FILE__}:#{line + 2}:7\">foo</p>", html
   ensure
@@ -730,7 +730,7 @@ class AttributeInjectionTest < Minitest::Test
       { 'data-papercraft-fn' => fn, 'data-papercraft-loc' => "foo://#{fn}:#{line}:#{col}" }
     }
 
-    html = Papercraft.render(t)
+    html = Papercraft.html(t)
 
     assert_equal "<p data-papercraft-fn=\"#{__FILE__}\" data-papercraft-loc=\"foo://#{__FILE__}:#{line + 2}:7\" class=\"bar\" baz>foo</p>", html
   ensure
@@ -748,7 +748,7 @@ class AttributeInjectionTest < Minitest::Test
       { 'data-papercraft-fn' => fn, 'data-papercraft-loc' => "foo://#{fn}:#{line}:#{col}" }
     }
 
-    html = Papercraft.render(t)
+    html = Papercraft.html(t)
     assert_equal "<p data-papercraft-fn=\"#{__FILE__}\" data-papercraft-loc=\"foo://#{__FILE__}:#{line + 3}:7\" class=\"bar\" baz>foo</p>", html
   ensure
     Papercraft::Compiler.html_debug_attribute_injector = nil
@@ -768,7 +768,7 @@ class AttributeInjectionTest < Minitest::Test
       { 'data-papercraft-level' => level, 'data-papercraft-fn' => fn, 'data-papercraft-loc' => "foo://#{fn}:#{line}:#{col}" }
     }
 
-    html = Papercraft.render(t)
+    html = Papercraft.html(t)
 
     expected = "<div data-papercraft-level=\"1\" data-papercraft-fn=\"#{__FILE__}\" data-papercraft-loc=\"foo://#{__FILE__}:#{line + 2}:7\">" +
                "<h1 data-papercraft-level=\"2\" data-papercraft-fn=\"#{__FILE__}\" data-papercraft-loc=\"foo://#{__FILE__}:#{line + 3}:9\">" +
@@ -785,7 +785,7 @@ class RawIOnnerTextTest < Minitest::Test
       script 'let a = 1 & 2; let b = "abc";'
     }
 
-    assert_equal '<script>let a = 1 & 2; let b = "abc";</script>', Papercraft.render(t)
+    assert_equal '<script>let a = 1 & 2; let b = "abc";</script>', Papercraft.html(t)
   end
 
   def test_script_tag_module_with_content
@@ -793,7 +793,7 @@ class RawIOnnerTextTest < Minitest::Test
       script 'let a = 1 & 2; let b = "abc";', type: 'module'
     }
 
-    assert_equal '<script type="module">let a = 1 & 2; let b = "abc";</script>', Papercraft.render(t)
+    assert_equal '<script type="module">let a = 1 & 2; let b = "abc";</script>', Papercraft.html(t)
   end
 
   def test_style_tag_with_content
@@ -801,7 +801,7 @@ class RawIOnnerTextTest < Minitest::Test
       style 'a&b { color: black }'
     }
 
-    assert_equal '<style>a&b { color: black }</style>', Papercraft.render(t)
+    assert_equal '<style>a&b { color: black }</style>', Papercraft.html(t)
   end
 
   def test_script_tag_module_with_content
@@ -809,7 +809,7 @@ class RawIOnnerTextTest < Minitest::Test
       style 'a&b { color: black }', media: '(width < 500px)'
     }
 
-    assert_equal '<style media="(width < 500px)">a&b { color: black }</style>', Papercraft.render(t)
+    assert_equal '<style media="(width < 500px)">a&b { color: black }</style>', Papercraft.html(t)
   end
 end
 
@@ -822,17 +822,17 @@ class MethodChainingTest < Minitest::Test
     t = -> {
       foo
     }
-    assert_equal '<foo></foo>', Papercraft.render(t)
+    assert_equal '<foo></foo>', Papercraft.html(t)
 
     t = -> {
       foo[0]
     }
-    assert_equal '<foo></foo>', Papercraft.render(t)
+    assert_equal '<foo></foo>', Papercraft.html(t)
 
     buf = []
     t = -> {
       buf.size
     }
-    assert_equal '', Papercraft.render(t)
+    assert_equal '', Papercraft.html(t)
   end
 end

--- a/test/test_xml.rb
+++ b/test/test_xml.rb
@@ -6,7 +6,37 @@ require 'time'
 require 'papercraft'
 
 class HtmlTest < Minitest::Test
-  def test_rss_generation
+  def test_xml_for_html_void_elements
+    t = -> {
+      link 'foo'
+    }
+    assert_equal "<link>foo</link>", Papercraft.xml(t)
+  end
+
+  def test_xml_self_closing_tag
+    t = -> {
+      foo
+    }
+    assert_equal '<foo/>', Papercraft.xml(t)
+
+    t = -> {
+      foo bar: "baz"
+    }
+    assert_equal '<foo bar="baz"/>', Papercraft.xml(t)
+  end
+
+  def test_xml_custom_tag
+    t = -> {
+      tag('atom:link',
+        href:"https://noteflakes.com/feeds/rss",
+        rel:"self", type: "application/rss+xml"
+      )
+    }
+    assert_equal '<atom:link href="https://noteflakes.com/feeds/rss" rel="self" type="application/rss+xml"/>',
+      Papercraft.xml(t)
+  end
+
+  def test_xml_rss_generation
     entries = [
       {
         title:  'foo',
@@ -30,7 +60,10 @@ class HtmlTest < Minitest::Test
           description 'Foo RSS'
           language 'en-us'
           pubDate 'Thu, 11 Sep 2025 08:00:00 GMT'
-          raw '<atom:link href="https://noteflakes.com/feeds/rss" rel="self" type="application/rss+xml" /> '
+          tag('atom:link',
+            href:"https://noteflakes.com/feeds/rss",
+            rel:"self", type: "application/rss+xml"
+          )
 
           entries.each { |e|
             item {
@@ -45,7 +78,7 @@ class HtmlTest < Minitest::Test
       }
     }
 
-    expected = '<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom"><channel><title>Foo</title><link>https://foo.com/</link><description>Foo RSS</description><language>en-us</language><pubDate>Thu, 11 Sep 2025 08:00:00 GMT</pubDate><atom:link href="https://noteflakes.com/feeds/rss" rel="self" type="application/rss+xml" /> <item><title>foo</title><link>https://noteflakes.com/01-foo</link><guid>https://noteflakes.com/01-foo</guid><pubDate>Tue, 01 Jan 2025 00:00:00 GMT</pubDate><description>&lt;h1 id=&quot;foo--bar&quot;&gt;Foo &amp;amp; Bar&lt;/h1&gt;</description></item><item><title>bar</title><link>https://noteflakes.com/02-bar</link><guid>https://noteflakes.com/02-bar</guid><pubDate>Sat, 02 Feb 2025 00:00:00 GMT</pubDate><description>&lt;h1 id=&quot;bar--baz&quot;&gt;Bar &amp;amp; Baz&lt;/h1&gt;</description></item></channel></rss>'
+    expected = '<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom"><channel><title>Foo</title><link>https://foo.com/</link><description>Foo RSS</description><language>en-us</language><pubDate>Thu, 11 Sep 2025 08:00:00 GMT</pubDate><atom:link href="https://noteflakes.com/feeds/rss" rel="self" type="application/rss+xml"/><item><title>foo</title><link>https://noteflakes.com/01-foo</link><guid>https://noteflakes.com/01-foo</guid><pubDate>Tue, 01 Jan 2025 00:00:00 GMT</pubDate><description>&lt;h1 id=&quot;foo--bar&quot;&gt;Foo &amp;amp; Bar&lt;/h1&gt;</description></item><item><title>bar</title><link>https://noteflakes.com/02-bar</link><guid>https://noteflakes.com/02-bar</guid><pubDate>Sat, 02 Feb 2025 00:00:00 GMT</pubDate><description>&lt;h1 id=&quot;bar--baz&quot;&gt;Bar &amp;amp; Baz&lt;/h1&gt;</description></item></channel></rss>'
     assert_equal expected, Papercraft.xml(t)
   end
 end

--- a/test/test_xml.rb
+++ b/test/test_xml.rb
@@ -46,6 +46,6 @@ class HtmlTest < Minitest::Test
     }
 
     expected = '<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom"><channel><title>Foo</title><link>https://foo.com/</link><description>Foo RSS</description><language>en-us</language><pubDate>Thu, 11 Sep 2025 08:00:00 GMT</pubDate><atom:link href="https://noteflakes.com/feeds/rss" rel="self" type="application/rss+xml" /> <item><title>foo</title><link>https://noteflakes.com/01-foo</link><guid>https://noteflakes.com/01-foo</guid><pubDate>Tue, 01 Jan 2025 00:00:00 GMT</pubDate><description>&lt;h1 id=&quot;foo--bar&quot;&gt;Foo &amp;amp; Bar&lt;/h1&gt;</description></item><item><title>bar</title><link>https://noteflakes.com/02-bar</link><guid>https://noteflakes.com/02-bar</guid><pubDate>Sat, 02 Feb 2025 00:00:00 GMT</pubDate><description>&lt;h1 id=&quot;bar--baz&quot;&gt;Bar &amp;amp; Baz&lt;/h1&gt;</description></item></channel></rss>'
-    assert_equal expected, Papercraft.render_xml(t)
+    assert_equal expected, Papercraft.xml(t)
   end
 end

--- a/test/test_xml.rb
+++ b/test/test_xml.rb
@@ -46,6 +46,6 @@ class HtmlTest < Minitest::Test
     }
 
     expected = '<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom"><channel><title>Foo</title><link>https://foo.com/</link><description>Foo RSS</description><language>en-us</language><pubDate>Thu, 11 Sep 2025 08:00:00 GMT</pubDate><atom:link href="https://noteflakes.com/feeds/rss" rel="self" type="application/rss+xml" /> <item><title>foo</title><link>https://noteflakes.com/01-foo</link><guid>https://noteflakes.com/01-foo</guid><pubDate>Tue, 01 Jan 2025 00:00:00 GMT</pubDate><description>&lt;h1 id=&quot;foo--bar&quot;&gt;Foo &amp;amp; Bar&lt;/h1&gt;</description></item><item><title>bar</title><link>https://noteflakes.com/02-bar</link><guid>https://noteflakes.com/02-bar</guid><pubDate>Sat, 02 Feb 2025 00:00:00 GMT</pubDate><description>&lt;h1 id=&quot;bar--baz&quot;&gt;Bar &amp;amp; Baz&lt;/h1&gt;</description></item></channel></rss>'
-    assert_equal expected, t.render_xml
+    assert_equal expected, Papercraft.render_xml(t)
   end
 end


### PR DESCRIPTION
This PR changes the Papercraft API to remove the `Proc#render`, `Proc#apply` and similar methods, and instead add `Papercraft#render`, `Papercraft#apply` etc.

## Discussion

Some objections have been made to the fact that Papercraft extends the `Proc` class with a bunch of methods, and most importantly `#render` and `#apply`. This PR introduces a different API, where those methods are removed, and instead to render templates we need to use `Papercraft.render`, `Papercraft.apply` etc:

```ruby
templ = ->(name) { h1 name }

# before:
templ.render('foo')

# after:
Papercraft.render(templ, 'foo')

# same for apply
layout = -> (**props) {
  html {
    body {
      render_children(**props)
    }
  }
}

page = Papercraft.apply(layout) { |title:, **props| h1 title }
Papercraft.render(page, title: 'foo')
```

Note that Papercraft still extends Proc with some methods needed for storing and accessing template-specific metadata related to compilation and cached rendering. Those methods are prefixed and postfixed with double underscores. Those methods are used internally, and are not called directly by application code.

## Release

If merged, this will be released as version 3.0.